### PR TITLE
Add Waldium to New and Emerging AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ This section introduces the latest AI tools that are gaining popularity and have
 - **[Taskade](https://www.taskade.com/)** - Build, train, and deploy autonomous AI agents for task management, team collaboration, and workflow automation within a unified workspace, enhancing team productivity with structured lists, notes, and mind maps.
 - **[AI Boost](https://boost.pictures/)** - All-in-one service for creating and editing images with AI: upscale images, swap faces, generate new visuals and avatars, try on outfits, reshape body contours, change backgrounds, retouch faces, and even test out tattoos.
 - **[Serplux](https://serplux.com/)** - 400+ free AL tools and AI SEO Agents for digital marketing.
-- 
+- **[Waldium](https://waldium.com)** - AI-powered blogs to help ChatGPT/Claude/Perplexity cite your product.
 
 
 ---


### PR DESCRIPTION
Added Waldium - Generates AI-powered blogs to help ChatGPT/Claude/Perplexity cite your product.

- Added one-line neutral description  
- Link verified and tool is live  
- Placed at the end of the "New and Emerging AI Tools" section
