### PR TITLE
Add Havoptic to Code Assistants section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,7 @@ ______________________________________________________________________________
 - [Codex by OpenAI](https://openai.com/blog/openai-codex/) - AI system that translates natural language to code, powered by GPT-3.
 - [Deep TabNine Local](https://www.tabnine.com/local) - Deep learning model running locally for code completion.
 - [Berrry](https://berrry.app) - AI-powered platform that transforms Twitter posts and Reddit content into functional web applications using code generation.
+- [Havoptic](https://havoptic.com/) - Free, open-source release tracker for AI coding tools. Aggregates changelogs from Cursor, Codex CLI, Gemini CLI, and more.
 
 ______________________________________________________________________________
 


### PR DESCRIPTION
## Add Havoptic

Adding Havoptic to the AI-Powered Compilers and Code Assistants section.

**Website:** https://havoptic.com  
**Repository:** https://github.com/scotthavird/havoptic.com  
**License:** MIT

**Description:** A free, open-source release tracker for AI coding tools. Aggregates changelogs from Cursor, Codex CLI, Gemini CLI, Kiro CLI, and more. Auto-updated daily via GitHub Actions.

Helps developers track new releases across the AI coding tool ecosystem.