### PR TITLE
Add Price Per Token to LLM Ops section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,6 +1145,7 @@ ______________________________________________________________________________
 - [Mem0](https://github.com/mem0ai/mem0) - The memory layer for Personalized AI
 - [Inferable](https://github.com/inferablehq/inferable) - Open-source managed agent runtime for distributed AI agents
 - [Gestell](https://gestell.ai) - Gestell takes your messy, unstructured data and turns it into organized, searchable databases so your AI can find answers quickly and accurately at any scale.
+- [Price Per Token](https://pricepertoken.com/) - Compare LLM API pricing across 300+ models from all major providers with token counters, cost calculators, and benchmark data.
 
 ______________________________________________________________________________
 


### PR DESCRIPTION
## Summary
Adding Price Per Token to the LLM Ops section alongside similar tools like Keywords AI and Helicone AI.

## About Price Per Token
- Compare LLM API pricing across 300+ models
- Covers all major providers (OpenAI, Anthropic, Google, Mistral, etc.)
- Includes token counters and cost calculators
- Provides benchmark data for performance comparison

**Link:** https://pricepertoken.com/