### PR TITLE
Add AppDeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1166,6 +1166,7 @@ A selection of platforms offering API integration for various AI applications an
 - [GoCodeo](https://www.gocodeo.com/) - AI agent for building full-stack apps in minutes.
 - [JetBrains Compose Multiplatform](https://www.jetbrains.com/lp/compose-multiplatform/) - AI-assisted code completion for Kotlin multiplatform development.
 - [MyVibe](https://www.myvibe.so) - Instant deployment for AI-coded projects via Claude Code.
+- [AppDeploy](https://appdeploy.ai) - Describe what you want to build to your favorite AI assistant, such as ChatGPT, Claude, or any other MCP client. AppDeploy deploys it, handles the frontend and backend services, and gives you a live URL.
 - [Tabnine](https://www.tabnine.com/) - AI code completion assistant for software developers, supporting multiple languages and IDEs.
 - [Kite](https://www.kite.com/) - AI coding assistant offering line-of-code completions and documentation.
 - [Codota](https://www.codota.com/) - AI tool for developers that predicts your next code segment.


### PR DESCRIPTION
## Summary
- Adds [AppDeploy](https://appdeploy.ai) to the **AI-Powered Compilers and Code Assistants** section
- AppDeploy is a chat-native deployment platform — describe what you want to build to your favorite AI assistant (ChatGPT, Claude, or any MCP client), and AppDeploy deploys it, handles frontend and backend services, and gives you a live URL
- Works with any MCP client via `https://api-v2.appdeploy.ai/mcp`