### PR TITLE
Add Poirot to AI Code Assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1173,6 +1173,7 @@ A selection of platforms offering API integration for various AI applications an
 - [Intellicode](https://visualstudio.microsoft.com/services/intellicode/) - AI-assisted coding from Microsoft, available in Visual Studio.
 - [SourceAI](https://sourceai.dev/) - An AI-powered code generator that helps you write code faster.
 - [unpkg.ai](https://unpkg.ai/) - AI-powered service that generates JavaScript modules with TypeScript signatures via URL for rapid prototyping.
+- [Poirot](https://github.com/LeonardoCardoso/Poirot) - A macOS app for browsing Claude Code sessions, exploring diffs, and re-running commands. Reads local transcripts, runs offline, open source.
 - [poorcoder](https://github.com/vgrichina/poorcoder) - Lightweight Bash scripts that enhance your terminal coding workflow with web-based AI assistants like Claude or Grok.
 - [AI Code Completion by DeepCode](https://www.deepcode.ai/) - AI-powered code review tool that learns from your codebase.
 - [Replit's Ghostwriter](https://replit.com/ghostwriter) - AI coding assistant that helps you write and debug code faster.


### PR DESCRIPTION
Poirot is an open source macOS app for browsing Claude Code sessions. It reads local JSONL transcripts and shows conversations, tool blocks, diffs, and lets you re-run commands. MIT licensed.

https://github.com/LeonardoCardoso/Poirot