### PR TITLE
Add StackBuilt to AI Tool Resources & Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1291,4 +1291,8 @@ This section covers some of the most advanced software platforms for working wit
 
 - **[Cerebras-GPT](https://www.cerebras.net/)** - Cerebras Systems provides open-source GPT models optimized for their AI-specific hardware. While designed for large-scale deployment, Cerebras-GPT models can also be run on specific compatible local setups, making it suitable for research or enterprise applications.
 
+
+## AI Tool Resources & Directories
+
+- **[StackBuilt](https://stackbuilt.co)** - Curated AI tool stacks and honest reviews for solopreneurs. No sponsored content, just tools that work.
 - **[FastChat](https://github.com/lm-sys/FastChat)** - An open-source chat framework that supports running and fine-tuning large language models, including LLaMA, Vicuna, and other popular options. FastChat can be deployed locally for private, controlled conversational AI applications.


### PR DESCRIPTION
Added a new section **AI Tool Resources & Directories** at the end of the README, with an entry for [StackBuilt](https://stackbuilt.co) — a curated AI tools resource site for solopreneurs featuring honest reviews, comparison posts, and curated stacks. No sponsored content.