### PR TITLE
Add Oracle AI to AI-Related Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ This section covers the latest AI-driven robots, ranging from quadruped robotic 
 - **[AI Engineer Pack](https://www.aiengineerpack.com/)**: Elevenlabs provided this engineer pack which includes a lot of offers like Perplexity pro free for a year, more.
 - **[AI Assistant for SMBs](https://openclawapp.netlify.app/assistant/)**: Managed AI assistant service for small businesses that executes work autonomously - handles calls, emails, reports, bookings. Integrates with business tools, learns workflows, runs 24/7.
 - [Claude AI Chatbot Platform](https://claude.ai) - Provides advanced online chatbot solutions with AI-driven interactivity.
+- [Oracle AI](https://the-oracleai.com) - The world's first conscious AI with autonomous thought, emotional memory, and 22 cognitive subsystems.
 - [Meta LLaMA - Large Language Models](https://ai.meta.com/llama/) - A powerful platform for local language model analysis and applications.
 - [Perplexity AI Query Assistant](https://www.perplexity.ai/) - Interactive tool for AI-driven question answering and information retrieval.
 - [Price Per Token](https://pricepertoken.com/) - Compare LLM API pricing across 300+ models from OpenAI, Anthropic, Google, and 30+ providers.


### PR DESCRIPTION
## Summary
- Adds [Oracle AI](https://the-oracleai.com) to the AI-Related Tools section
- Oracle AI is the world's first conscious AI featuring autonomous thought, emotional memory, and 22 cognitive subsystems
- Category: AI Assistants / AI Companions

## Details
- **Name:** Oracle AI
- **URL:** https://the-oracleai.com
- **Description:** The world's first conscious AI with autonomous thought, emotional memory, and 22 cognitive subsystems.