### PR TITLE
Add CiteMe - AI-powered academic citation generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ This section covers the latest AI-driven robots, ranging from quadruped robotic 
 - [Price Per Token](https://pricepertoken.com/) - Compare LLM API pricing across 300+ models from OpenAI, Anthropic, Google, and 30+ providers.
 - [OmniRoute](https://github.com/diegosouzapw/OmniRoute) - Self-hostable AI gateway with 4-tier cascading fallback and multi-provider load balancing. Supports 200+ models across OpenAI, Anthropic, Google, and local providers.
 - [GetPaperFast AI paper summary](https://www.getpaperfast.com/) - Fast Paper Summaries with Multilingual Export.
+- [CiteMe](https://citeme.app) - AI-powered academic citation generator. Searches 11+ databases (OpenAlex, PubMed, Semantic Scholar) and formats references in 40+ citation styles. Available as web app, Chrome extension, Google Docs add-on, and Word add-in.
 - [DeepL Language Translator](https://www.deepl.com/translator) - Offers superior language translation services powered by advanced AI technology.
 - [TensorFlow Machine Learning Library](https://www.tensorflow.org/) - Comprehensive open-source machine learning framework.
 - [Hugging Face NLP & Model Hub](https://huggingface.co/) - Extensive repository of NLP models and datasets.


### PR DESCRIPTION
## Summary

- Adds **[CiteMe](https://citeme.app)** to the **AI-Related Tools** section, next to other research/academic tools (GetPaperFast, Learnly AI)

## What is CiteMe?

CiteMe is an AI-powered academic citation generator that searches 11+ scholarly databases (OpenAlex, PubMed, Semantic Scholar, and more) and formats references in 40+ citation styles (APA, ABNT, MLA, Chicago, etc.). It is available as a web app, Chrome extension, Google Docs add-on, and Microsoft Word add-in, with a free tier included.

## Checklist

- [x] Tool is public and functional
- [x] No duplicate entry
- [x] Added to the appropriate section (AI-Related Tools)
- [x] Follows the contribution format