### PR TITLE
Add Steel Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,7 @@ A selection of platforms offering API integration for various AI applications an
 - [Codota](https://www.codota.com/) - AI tool for developers that predicts your next code segment.
 - [Intellicode](https://visualstudio.microsoft.com/services/intellicode/) - AI-assisted coding from Microsoft, available in Visual Studio.
 - [SourceAI](https://sourceai.dev/) - An AI-powered code generator that helps you write code faster.
+- [Steel Browser](https://github.com/steel-dev/steel-browser) - Open-source browser sandbox and automation infrastructure for AI agents and apps with session-backed workflows, screenshots, PDFs, proxies, and anti-bot tooling.
 - [unpkg.ai](https://unpkg.ai/) - AI-powered service that generates JavaScript modules with TypeScript signatures via URL for rapid prototyping.
 - [Poirot](https://github.com/LeonardoCardoso/Poirot) - A macOS app for browsing Claude Code sessions, exploring diffs, and re-running commands. Reads local transcripts, runs offline, open source.
 - [poorcoder](https://github.com/vgrichina/poorcoder) - Lightweight Bash scripts that enhance your terminal coding workflow with web-based AI assistants like Claude or Grok.


### PR DESCRIPTION
This adds Steel Browser to the AI-Powered Compilers and Code Assistants section.

Steel Browser is open-source browser sandbox and automation infrastructure for AI agents and apps. It fits here because it gives coding and agent workflows a real browser path with session-backed automation, screenshots, PDFs, proxies, and anti-bot tooling.

Links:
- Repo: https://github.com/steel-dev/steel-browser
- CLI: https://github.com/steel-dev/cli
- Docs: https://docs.steel.dev/llms-full.txt
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: use an AI coding workflow to automate a JS-heavy dashboard, extract content, and save screenshot and PDF artifacts.