### PR TITLE
Add Vocova

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,7 @@ A selection of AI tools specialized in voice recognition, synthesis, and process
 22. [YobiYoba](https://www.yobiyoba.com/en/) - Yobiyoba.com delivers state-of-the-art automatic transcription with a powerful editor and pricing based solely on speech time.
 23. [CustomPod](https://custompod.io/) - Improve productivity by getting a personalized daily audio briefing on updates from your favorite sites/apps.
 24. [EKHOS AI](https://ekhos.ai/) - A powerful speech-to-text software that transcribes audio and video files, supports real-time recording and transcription, and includes a built-in proofreading editor.
+25. [Vocova](https://vocova.app) - AI-powered transcription supporting 100+ languages with speaker diarization and bilingual export.
 
 ---
 


### PR DESCRIPTION
Adds [Vocova](https://vocova.app) — an AI transcription tool supporting 100+ languages with URL import from 1000+ platforms, speaker diarization, and bilingual export.

Free tier includes 120 minutes. No credit card required.