### PR TITLE
Add Igly to AI Tools for Photo Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,6 +1139,7 @@ A collection of AI-powered tools specifically designed for photo editing and enh
 18. [AirBrush](https://appairbrush.com) - Easy photo editor.
 19. [PhotoDirector](https://www.cyberlink.com/products/photodirector-photo-editing-software-365/overview_en_US.html) - Creative editing with AI style effects.
 20. [TouchRetouch](https://www.adva-soft.com/touchretouch/) - Remove objects from photos.
+21. [Igly](https://igly.ai) - AI image editor for background removal, replacement, upscale, restore, inpaint, and product-photo workflows.
 
 ---
 


### PR DESCRIPTION
Adds Igly (https://igly.ai) to the **AI Tools for Photo Editing** section.

Why it fits:
- public and usable product
- focused on AI image editing / product photo workflows
- includes background removal, replacement, upscale, restore, and inpaint

Note: I'm associated with the tool.