### PR TITLE
Add WhereMyTokens as Claude Code companion monitoring tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,9 @@ Claude Code is Anthropic’s agentic coding system designed to handle full softw
     - Cursor (agent mode)  
     - GitHub Copilot Agents  
   - Particularly strong in **long-context coding and large codebase understanding**
+
+- **Companion \& Monitoring Tools**:
+  - **[WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens)** – Windows system tray app for real-time Claude Code token usage, costs, rate limits, and session activity. Reads local JSONL files and integrates via the `statusLine` plugin.
 ---
 
 ### Meta AI


### PR DESCRIPTION
## Summary

Adds a **Companion & Monitoring Tools** subsection to the Claude Code section, with **WhereMyTokens** as the first entry.

- **Repo**: https://github.com/jeongwookie/WhereMyTokens
- **License**: MIT

## What it does

WhereMyTokens is a Windows system tray app that sits alongside Claude Code and provides real-time visibility into token usage, costs, and rate limits:

- **Live session list** — tracks all running Claude Code sessions with real-time status
- **Rate limit bars** — 5h and 1w usage from the Anthropic API with countdown timers
- **statusLine bridge** — registers as a Claude Code native plugin; receives live data via stdin (no API polling)
- **Context window warnings** — per-session alerts at 50% / 80% / 95%+
- **Activity heatmaps**, model cost breakdown, Windows toast alerts
- Pre-built portable `.exe`, no install needed

The Claude Code section currently covers the core product and its capabilities — adding companion tooling rounds it out for developers who want usage observability alongside their workflow.