### PR TITLE
Add WhereMyTokens to LLM Ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1814,6 +1814,7 @@ A selection of platforms offering API integration for various AI applications an
 - [OmniRoute](https://github.com/diegosouzapw/OmniRoute) - Self-hostable AI gateway with 4-tier cascading fallback and multi-provider load balancing. Supports 200+ models across OpenAI, Anthropic, Google, and local providers.
 - [BlackVault](https://github.com/venkat22022202/black-vault) - Open-source proxy gateway for AI API keys. Generate proxy tokens for agents — BlackVault injects the real key server-side and forwards to OpenAI, Anthropic, Google AI, and Nebius AI. Kill a token for instant revocation.
 - [LochBot](https://lochbot.com) - Free browser-based prompt injection vulnerability checker. Analyzes LLM system prompts against 31 attack patterns (jailbreaks, role override, data exfiltration) and returns a security score with remediation guidance. No signup, runs client-side.
+- [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Open-source Windows tray app for real-time Claude Code usage monitoring. Tracks per-session tokens, cost, context window, and 5h/1w rate limits from local JSONL session files and Claude Code's statusLine hook.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) to the **LLM Ops** section — an open-source Windows tray app for real-time Claude Code usage monitoring (tokens, cost, context window, and 5h/1w rate limits).

## Why this section
The LLM Ops section already covers LLM observability and cost tracking tools:
- Keywords AI, Helicone AI — LLM app monitoring / observability
- Price Per Token — token pricing / cost tracking

WhereMyTokens fits alongside these as a monitoring tool focused specifically on Claude Code usage, covering the end-user / desktop side of the same category.

## Change
One-line addition in the existing `## LLM Ops` section (no new subsections). Follows the format in CONTRIBUTING.md.

## Disclosure
I'm the author of the project. MIT-licensed, public GitHub repo, pre-built portable `.exe` available in releases.

## Note
A previous submission (#175) was closed because it was placed under the Claude Code section, which is reserved for official Anthropic tools. This PR follows that feedback and targets the correct category.

## Checklist
- [x] Checked for duplicates
- [x] Correct section (LLM Ops)
- [x] Follows CONTRIBUTING.md format (`- [Name](URL) - description`)
- [x] Concise and neutral description (no marketing language)
- [x] Tool is publicly accessible and usable