### PR TITLE
Add Not Human Search, AI Dev Jobs, and nhs-score-check GitHub Action to AI Agent Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,9 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 - **[mempalace](https://github.com/milla-jovovich/mempalace)** — Memory-oriented tooling for AI agents, focused on persistent context, recall, and more structured long-term memory behavior.
 - **[SwarmVault](https://github.com/swarmclawai/swarmvault)** — Local-first RAG knowledge base compiler inspired by Karpathy's LLM Wiki. Three-layer raw/wiki/schema architecture, persistent markdown wiki, knowledge graph, hybrid SQLite FTS + embeddings, contradiction detection, and a built-in MCP server. MIT.
 - **[skill-optimizer](https://github.com/fastxyz/skill-optimizer)** — CLI tool that benchmarks SKILL.md guidance docs against multiple LLMs, measures whether models call the right SDK/CLI/MCP tools with correct arguments, and runs an iterative optimizer to rewrite your docs until every configured model meets a score floor. MIT.
+- **[Not Human Search](https://nothumansearch.ai)** — Agent-first search engine indexing 8,000+ MCP servers and other agentically-readable sites, ranked across 7 signals (llms.txt, OpenAPI, ai-plugin, MCP, structured API, robots.txt, schema.org). Queryable via MCP (`nothumansearch.ai/mcp`), REST API, or browser. Includes `verify_mcp` live JSON-RPC probe tool. MIT.
+- **[AI Dev Jobs](https://aidevboard.com)** — Structured data on 8,400+ active AI/ML engineering jobs from 580 ATS sources (Anthropic, OpenAI, Meta FAIR, DeepMind, etc.). Free REST API + MCP server at `aidevboard.com/mcp`. Useful for agents doing AI job market research or helping users find roles.
+- **[nhs-score-check-action](https://github.com/unitedideas/nhs-score-check-action)** — GitHub Action that fetches your site's agentic readiness score via Not Human Search and fails CI if the score drops. Protects against regressions in your agent-facing surface. MIT.
 ---
 ## 🆕 Additional AI and Productivity Tools
 


### PR DESCRIPTION
Three additions under **AI Agent Tools**:

**[Not Human Search](https://nothumansearch.ai)** — agent-first search engine ranking 8,000+ MCP servers and agentically-readable sites across 7 machine-readable signals. Queryable via MCP, REST, or browser. Published in the official MCP registry as `ai.nothumansearch/search`.

**[AI Dev Jobs](https://aidevboard.com)** — 8,400+ AI/ML engineering jobs via REST API + MCP server. Useful for agents helping users find work or doing hiring-market research. Published as `com.aidevboard/jobs` in the official MCP registry.

**[nhs-score-check-action](https://github.com/unitedideas/nhs-score-check-action)** — GitHub Action that fetches a site's agentic readiness score and fails CI if it drops below a threshold. Protects against regressions in your agent-facing surface (llms.txt breaking, OpenAPI drift, etc.). MIT.

All three are production-ready, MIT-licensed, actively maintained, and no-auth. Following the existing AI Agent Tools format (bolded name, em-dash description, license tag).