### PR TITLE
Add Resumemind to Additional AI and Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,6 +1167,7 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 - [LearnClash](https://learnclash.com) - AI-powered 1v1 quiz duels on any topic with ELO rankings and spaced repetition. Free, no ads.
 - [DishRoll](https://dishroll.netlify.app/) - AI-powered weekly meal planner that generates personalised 7-day menus based on dietary needs, cuisine preferences, and grocery budget.
 - [StoryRoute](https://storyroute.netlify.app) - AI-powered GPS audio tour guide that generates real-time location-aware travel narratives as you explore cities. Free to use.
+- [Resumemind](https://resumemind.com) - An AI-powered resume builder and visual analyzer specifically tailored for software engineers.
 
 ---
 


### PR DESCRIPTION
Please complete the sections below. Submissions missing key details may be closed.

---

## Submission Summary

**Tool name:** Resumemind
**URL:** https://resumemind.com

**Your connection to the tool:**
creator

**AI involvement in this submission:**
none

---

## Details

### What does it do?
An AI-powered resume builder and visual analyzer specifically tailored for software engineers.

### Why should it be included?
Most resume builders are generic. Resumemind is highly niche, focusing purely on developers and engineering roles. It fits perfectly into the productivity stack for tech professionals preparing for the job market.

### Is it publicly available and usable right now?
- [x] Yes
- [ ] No

---

## Final checks

- [x] I checked for duplicates
- [x] I added it to the correct category
- [x] I used the required format
- [x] The description is short and neutral

---

### Transparency note

No automated agents were used to generate this PR submission.