### PR TITLE
Add AIWatch to LLM Ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1816,6 +1816,7 @@ A selection of platforms offering API integration for various AI applications an
 - [BlackVault](https://github.com/venkat22022202/black-vault) - Open-source proxy gateway for AI API keys. Generate proxy tokens for agents — BlackVault injects the real key server-side and forwards to OpenAI, Anthropic, Google AI, and Nebius AI. Kill a token for instant revocation.
 - [LochBot](https://lochbot.com) - Free browser-based prompt injection vulnerability checker. Analyzes LLM system prompts against 31 attack patterns (jailbreaks, role override, data exfiltration) and returns a security score with remediation guidance. No signup, runs client-side.
 - [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Open-source Windows tray app for real-time Claude Code usage monitoring. Tracks per-session tokens, cost, context window, and 5h/1w rate limits from local JSONL session files and Claude Code's statusLine hook.
+- [AIWatch](https://ai-watch.dev) - Open-source real-time status dashboard for 30 AI services (Claude, OpenAI, Gemini, Mistral, Groq, and more). AI-powered incident analysis via hybrid Gemma 4 + Claude Sonnet, early detection vs official status pages, reliability scoring, Discord/Slack webhooks. Stack: Cloudflare Workers + KV + Workers AI.
 
 ---
 


### PR DESCRIPTION
Adds **AIWatch** to the `LLM Ops` section.

**AIWatch** — https://ai-watch.dev

Real-time status dashboard for 30 AI services (Claude, OpenAI, Gemini, Mistral, Cohere, Groq, Fireworks, Together, and more) with:

- **AI-powered incident analysis** — hybrid Gemma 4 26B (Cloudflare Workers AI binding) + Claude Sonnet (fallback via AI Gateway). Summarizes cause + estimated recovery time per incident.
- **Early detection** — direct API probing every 5 min catches outages ahead of official status pages ("Detection Lead" metric surfaced in alerts).
- **Reliability scoring** — composite 0-100 score combining uptime, incident impact days (Atlassian-weighted), recovery time, and response consistency.
- **Discord/Slack webhooks** — real-time alerts with AI analysis + fallback recommendations.
- **Open source, free to access, no account required.**

Stack: Cloudflare Workers + KV + Workers AI + React 19 + Vite.

GitHub: https://github.com/bentleypark/aiwatch

### Placement rationale

Placed in `LLM Ops` alongside other observability/monitoring tools (Helicone AI, Keywords AI, WhereMyTokens). AIWatch monitors AI *services* rather than individual LLM call traces, but the observability intent matches the section.