### PR TITLE
Add AI Context Linter, AI Context Templates, and url-to-md

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,9 @@ This section covers the latest AI-driven robots, ranging from quadruped robotic 
 - [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Hosted MCP server for searching scientific papers with full-text experimental data. 50 free searches, no API key needed.
 - [DeepL Language Translator](https://www.deepl.com/translator) - Offers superior language translation services powered by advanced AI technology.
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - GitHub Action that automatically translates i18n files (XLIFF, JSON) using LLM providers (Anthropic, OpenAI, Ollama) with glossary support, change detection, and reviewed translation preservation.
+- [AI Context Linter](https://github.com/MrDwarf7/ai-context-linter) - GitHub Action that lints AI coding context files (CLAUDE.md, .cursorrules, AGENTS.md) for security issues, structural problems, and AI anti-patterns.
+- [AI Context Templates](https://github.com/MrDwarf7/ai-context-templates) - Free CLAUDE.md, Cursor rules, and PRP templates that make AI coding assistants actually useful. 5 ready-to-use template packs for common project types.
+- [url-to-md](https://github.com/MrDwarf7/url-to-md) - Any URL to clean markdown for LLMs. Free API, no signup required. Strips JS/CSS and outputs LLM-ready content.
 - [TensorFlow Machine Learning Library](https://www.tensorflow.org/) - Comprehensive open-source machine learning framework.
 - [Hugging Face NLP & Model Hub](https://huggingface.co/) - Extensive repository of NLP models and datasets.
 - [Algorithmia AI Model Deployment](https://algorithmia.com/) - Platform for scalable AI and machine learning model deployment.


### PR DESCRIPTION
Adding three open-source AI developer tools to the AI-Related Tools section:

1. **AI Context Linter** (https://github.com/MrDwarf7/ai-context-linter) - GitHub Action that lints CLAUDE.md, .cursorrules, and AGENTS.md files for security issues, structural problems, and AI anti-patterns. Free, open-source, published on GitHub Marketplace.

2. **AI Context Templates** (https://github.com/MrDwarf7/ai-context-templates) - Free, ready-to-use CLAUDE.md and Cursor rules template packs for 5 common project types. Helps developers get better results from AI coding assistants.

3. **url-to-md** (https://github.com/MrDwarf7/url-to-md) - URL-to-markdown converter for LLMs. Free API, no signup, strips JS/CSS for clean LLM-ready output.

Disclosure: I am the creator of these tools. All are publicly available and actively maintained.