### PR TITLE
Add Scrupp to AI-Focused Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,6 +1222,7 @@ The following are online platforms where you can rent GPU resources, ideal for r
 18. **ChatGPT for Google** - Integrate ChatGPT in Google searches.
 19. **Almighty** - AI-driven productivity booster.
 20. **SentiSum Insights** - AI sentiment analysis for customer feedback.
+21. **[Scrupp](https://scrupp.com/)** - #1 Sales Navigator Scraper Chrome extension. Exports 2,500 LinkedIn / Sales Navigator leads per search to CSV with SMTP-verified emails and phone numbers via AI-assisted waterfall enrichment.
 
 ---
 


### PR DESCRIPTION
Adds [Scrupp](https://scrupp.com/) to the **AI-Focused Extensions** section.

Scrupp is a Chrome extension that scrapes LinkedIn and Sales Navigator with AI-assisted waterfall enrichment. Exports up to 2,500 leads per search to CSV with SMTP-verified work emails and direct phone numbers. Useful for SDR and outbound prospecting workflows.

Free plan available — 100 verified-email exports, no credit card.