### PR TITLE
Add Embedding Similarity Calculator to the 🛠️ LLM Ops section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1817,7 +1817,7 @@ A selection of platforms offering API integration for various AI applications an
 - [BlackVault](https://github.com/venkat22022202/black-vault) - Open-source proxy gateway for AI API keys. Generate proxy tokens for agents — BlackVault injects the real key server-side and forwards to OpenAI, Anthropic, Google AI, and Nebius AI. Kill a token for instant revocation.
 - [LochBot](https://lochbot.com) - Free browser-based prompt injection vulnerability checker. Analyzes LLM system prompts against 31 attack patterns (jailbreaks, role override, data exfiltration) and returns a security score with remediation guidance. No signup, runs client-side.
 - [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Open-source Windows tray app for real-time Claude Code usage monitoring. Tracks per-session tokens, cost, context window, and 5h/1w rate limits from local JSONL session files and Claude Code's statusLine hook.
-- **[Embedding Similarity Calculator](https://uatgpt.com/tools/embedding-similarity/)** - Compute cosine, dot, Euclidean, Manhattan, and Hamming similarity between two vectors, with ANN algorithm recommendation (FLAT / HNSW / IVF+PQ) matched to corpus scale and recall targets.
+- [Embedding Similarity Calculator](https://uatgpt.com/tools/embedding-similarity/) - Compute cosine, dot, Euclidean, Manhattan, and Hamming similarity between two vectors, with ANN algorithm recommendation (FLAT / HNSW / IVF+PQ) matched to corpus scale and recall targets.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1817,6 +1817,7 @@ A selection of platforms offering API integration for various AI applications an
 - [BlackVault](https://github.com/venkat22022202/black-vault) - Open-source proxy gateway for AI API keys. Generate proxy tokens for agents — BlackVault injects the real key server-side and forwards to OpenAI, Anthropic, Google AI, and Nebius AI. Kill a token for instant revocation.
 - [LochBot](https://lochbot.com) - Free browser-based prompt injection vulnerability checker. Analyzes LLM system prompts against 31 attack patterns (jailbreaks, role override, data exfiltration) and returns a security score with remediation guidance. No signup, runs client-side.
 - [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Open-source Windows tray app for real-time Claude Code usage monitoring. Tracks per-session tokens, cost, context window, and 5h/1w rate limits from local JSONL session files and Claude Code's statusLine hook.
+- **[Embedding Similarity Calculator](https://uatgpt.com/tools/embedding-similarity/)** - Compute cosine, dot, Euclidean, Manhattan, and Hamming similarity between two vectors, with ANN algorithm recommendation (FLAT / HNSW / IVF+PQ) matched to corpus scale and recall targets.
 
 ---
 


### PR DESCRIPTION
Adds Embedding Similarity Calculator to the 🛠️ LLM Ops section.

What it does:
- Computes cosine, dot product, Euclidean, Manhattan, and Hamming similarity between two embedding vectors.
- Recommends an ANN algorithm (FLAT / HNSW / IVF+PQ / distributed) matched to corpus scale, latency, and recall targets.
- Includes 5 embedding model profiles for use-case-specific threshold guidance.
- Runs client-side in the browser — no sign-up, no server call, free.

Fit for LLM Ops:
- Sits next to infrastructure and cost tooling already in the section (e.g. Price Per Token).
- Covers the pre-deploy sizing question developers face when picking vector DBs and ANN indexes.

Transparency (per CONTRIBUTING):
- I used an AI assistant to help draft this PR description. The tool itself, its code, and its UX are hand-built and client-side.

Happy to adjust wording, section placement, or entry format if preferred.