### PR TITLE
feat: add KubeStellar Console to LLM Ops section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1878,6 +1878,7 @@ A selection of platforms offering API integration for various AI applications an
 - [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) - Open-source Windows tray app for real-time Claude Code usage monitoring. Tracks per-session tokens, cost, context window, and 5h/1w rate limits from local JSONL session files and Claude Code's statusLine hook.
 - [AIWatch](https://ai-watch.dev) - Open-source real-time status dashboard for 30 AI services (Claude, OpenAI, Gemini, Mistral, Groq, and more). AI-powered incident analysis via hybrid Gemma 4 + Claude Sonnet, early detection vs official status pages, reliability scoring, Discord/Slack webhooks. Stack: Cloudflare Workers + KV + Workers AI.
 - [Embedding Similarity Calculator](https://uatgpt.com/tools/embedding-similarity/) - Compute cosine, dot, Euclidean, Manhattan, and Hamming similarity between two vectors, with ANN algorithm recommendation (FLAT / HNSW / IVF+PQ) matched to corpus scale and recall targets.
+- [KubeStellar Console](https://github.com/kubestellar/console) - Open-source multi-cluster Kubernetes dashboard with an MCP server (kc-agent) that enables AI coding agents to query and manage clusters via natural language. Integrates with 20+ CNCF projects for AI-assisted operations across edge and cloud.
 ---
 
 ## 🛠️ REPOS


### PR DESCRIPTION
## What is this?

[KubeStellar Console](https://github.com/kubestellar/console) is an open-source multi-cluster Kubernetes dashboard with an integrated MCP server (`kc-agent`).

## Why it belongs in LLM Ops

KubeStellar Console's kc-agent is a native MCP server that enables AI coding agents (Claude Code, Copilot, Codex) to:
- Query and manage multi-cluster Kubernetes resources via natural language.
- Perform AI-assisted workload placement, policy enforcement, and incident response.
- Bridge LLM workflows to real Kubernetes infrastructure.

The console integrates with 20+ CNCF projects and is itself a CNCF Sandbox project.

Added at the bottom of the LLM Ops section, matching the existing list format.