### PR TITLE
Add prompt-to-asset (image gen MCP) and unslop (AI writing cleaner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,7 @@ This section covers the latest AI-driven robots, ranging from quadruped robotic 
 - [OmniRoute](https://github.com/diegosouzapw/OmniRoute) - Self-hostable AI gateway with 4-tier cascading fallback and multi-provider load balancing. Supports 200+ models across OpenAI, Anthropic, Google, and local providers.
 - [GetPaperFast AI paper summary](https://www.getpaperfast.com/) - Fast Paper Summaries with Multilingual Export.
 - [CiteMe](https://citeme.app) - AI-powered academic citation generator. Searches 11+ databases (OpenAlex, PubMed, Semantic Scholar) and formats references in 40+ citation styles. Available as web app, Chrome extension, Google Docs add-on, and Word add-in.
+- [unslop](https://github.com/MohamedAbdallah-14/unslop) - CLI that strips AI writing patterns (sycophantic openers, filler phrases, em-dash overuse) from text files and stdin. Pass through code blocks and URLs unchanged. `npm install -g unslop`.
 - [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - Hosted MCP server for searching scientific papers with full-text experimental data. 50 free searches, no API key needed.
 - [DeepL Language Translator](https://www.deepl.com/translator) - Offers superior language translation services powered by advanced AI technology.
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - GitHub Action that automatically translates i18n files (XLIFF, JSON) using LLM providers (Anthropic, OpenAI, Ollama) with glossary support, change detection, and reviewed translation preservation.
@@ -1495,6 +1496,7 @@ This list highlights a selection of image generation tools, featuring advanced A
 - [Nsketch AI](https://nsketch.ai) - AI image and video generation platform with 20+ models and ready-made templates for creators.
 - [Eye Type Detector](https://eyeshapedetector.app/) - Eye Shape Detector with AI|Finder eye shape
 - [Shortodella](https://shortodella.com) - AI graphics platform with a canvas editor for image generation, video creation, chat-based editing, and background removal. Free tier available.
+- [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server that routes image generation prompts across 30+ models (Flux, DALL-E, Stable Diffusion, etc). Zero API key required for first run via free tiers. `npm install -g prompt-to-asset`.
 
 
 ---


### PR DESCRIPTION
## What this adds

Two open-source developer tools:

**[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset)** — Added to Image Generation Tools. An MCP server that routes image generation prompts across 30+ models (Flux, DALL-E, Stable Diffusion, Ideogram, etc.). Zero API key required for the first run via free tiers. Install: `npm install -g prompt-to-asset`.

**[unslop](https://github.com/MohamedAbdallah-14/unslop)** — Added to AI-Related Tools. A CLI tool that strips AI writing patterns (sycophantic openers, filler vocabulary, hedging stacks, em-dash overuse) from text files and stdin before publication. Code blocks, URLs, and technical terms pass through unchanged. Install: `npm install -g unslop`.

Both tools are published on npm, MIT-licensed, actively maintained, and usable today. I'm the author of both.