### PR TITLE
Add TranscribeText to audio transcription section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<img width="3746" height="2098" alt="image" src="https://github.com/user-attachments/assets/fec744aa-419a-4617-92d3-e523b38d8baa" />
 [![Awesome](https://img.shields.io/badge/Awesome-AI-000000.svg?logo=github&labelColor=24292e)](#)
 ![GitHub Stars](https://img.shields.io/github/stars/eudk/awesome-ai-tools?style=social)
 ![GitHub Forks](https://img.shields.io/github/forks/eudk/awesome-ai-tools?style=social)
@@ -1695,9 +1696,10 @@ A selection of AI tools specialized in voice recognition, synthesis, and process
 22. [YobiYoba](https://www.yobiyoba.com/en/) - Yobiyoba.com delivers state-of-the-art automatic transcription with a powerful editor and pricing based solely on speech time.
 23. [CustomPod](https://custompod.io/) - Improve productivity by getting a personalized daily audio briefing on updates from your favorite sites/apps.
 24. [EKHOS AI](https://ekhos.ai/) - A powerful speech-to-text software that transcribes audio and video files, supports real-time recording and transcription, and includes a built-in proofreading editor.
-25. [Vocova](https://vocova.app) - AI-powered transcription supporting 100+ languages with speaker diarization and bilingual export.
-26. [voicetoinstrument.com](https://voicetoinstrument.com) - Convert voice to instrument tracks using AI for music production and audio content creation.
-27. [AnveVoice](https://anvevoice.app) - Voice AI agent for websites with agentic DOM actions — navigates pages, fills forms, clicks buttons autonomously. 50+ languages, <700ms latency, one-line embed. Free tier.
+25. [TranscribeText](https://transcribetext.com) - AI-powered transcription supporting 41+ languages with speaker diarization, subtitle translation, and direct YouTube URL input. Extremely fast — a 2-hour audio file is processed in under 2 minutes.
+26. [Vocova](https://vocova.app) - AI-powered transcription supporting 100+ languages with speaker diarization and bilingual export.
+27. [voicetoinstrument.com](https://voicetoinstrument.com) - Convert voice to instrument tracks using AI for music production and audio content creation.
+28. [AnveVoice](https://anvevoice.app) - Voice AI agent for websites with agentic DOM actions — navigates pages, fills forms, clicks buttons autonomously. 50+ languages, <700ms latency, one-line embed. Free tier.
 
 ---
 


### PR DESCRIPTION
## Submission Summary

**Tool name:** TranscribeText
**URL:** https://transcribetext.com
**Your connection to the tool:** Creator (I built and run this service)
**AI involvement in this submission:** Some assistance

---

## Details

### What does it do?
AI-powered transcription service supporting 41+ languages. Features include speaker diarization, SRT/VTT subtitle export, subtitle translation between any language pair, and direct YouTube URL input. Processes a 2-hour audio file in under 2 minutes.

### Why should it be included?
Most transcription tools are English-first and underperform on tonal and non-Latin script languages. TranscribeText specifically targets under-served languages like Chinese, Tamil, Vietnamese, Japanese, and Korean with reliable accuracy. It fills a gap next to EKHOS AI and Vocova already listed in the section.

### Is it publicly available and usable right now?
- [x] Yes
- [ ] No

---

## Final checks

- [x] I checked for duplicates
- [x] I added it to the correct category
- [x] I used the required format
- [x] The description is short and neutral

---

### Transparency note
Submission prepared with some AI writing assistance. The tool itself is real and fully operational.