### PR TITLE
Add AI Visibility Monitor (open-source AI citation tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1978,6 +1978,7 @@ This section covers some of the most advanced software platforms for working wit
 ---
 ## SEO related tools
 - If your tool is related to SEO feel free to insert it here
+- [AI Visibility Monitor](https://github.com/WorkSmartAI-alt/ai-visibility-monitor) - Open-source Python toolkit that tracks whether ChatGPT, Claude, and Perplexity cite your site. MIT license, runs locally on your credentials.
 
 ---
 ## New Github Projects


### PR DESCRIPTION
Adds AI Visibility Monitor to the SEO related tools section, which the README explicitly invites contributions to.

What it does: open-source Python toolkit that tracks whether ChatGPT, Claude, Perplexity, and Gemini cite your site for buyer-intent queries. Pulls Google Search Console and GA4 data, checks robots.txt and llms.txt for AI bot crawl readiness, and runs Claude with web_search to record citation patterns.

License: MIT
Cost to run: \$1-3 per citation check via Anthropic API; rest is free
Repo: https://github.com/WorkSmartAI-alt/ai-visibility-monitor

Built for solo operators and lean consulting practices priced out of \$300-500/month SaaS alternatives like Otterly, Peec, and Profound. Submission follows the format and contribution guidelines in CONTRIBUTING.md.

Disclosure: I'm the maintainer of the AI Visibility Monitor repo.