### PR TITLE
Add Bernstein to Multi-Agent / Orchestration Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,6 +1144,8 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 
 ### Multi-Agent / Orchestration Frameworks
 
+- **[Bernstein](https://github.com/sipyourdrink-ltd/bernstein)** — Multi-agent orchestrator for CLI coding agents (Claude Code, Codex CLI, Gemini CLI, and 34 more). Deterministic Python scheduler, first-class MCP server, file-based state, quality gates, cost tracking. Apache-2.0.
+
 - **[CrewAI](https://github.com/crewAIInc/crewAI)** — Framework for orchestrating teams of specialized AI agents. Role-based agents collaborate on complex tasks. $20M+ in VC funding. Apache-2.0.
 
 - **[LangChain](https://github.com/langchain-ai/langchain)** — One of the most widely used frameworks for building LLM-powered agents and chains. Extensive integrations. Raised $125M at $1.25B valuation (Oct 2025). MIT.


### PR DESCRIPTION
Adds Bernstein under **Multi-Agent / Orchestration Frameworks**.

[Bernstein](https://github.com/sipyourdrink-ltd/bernstein) is an open-source multi-agent orchestrator for CLI coding agents. It coordinates 37 cooperating CLI adapters (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot, Cursor, Aider, Amp, OpenHands, OpenCode, Goose, Qwen, Ollama, and 25 more) using a deterministic Python scheduler, so coordination uses zero LLM tokens.

Facts:
- Public, installable today: `pipx install bernstein`
- License: Apache-2.0
- Language: Python 3.12+
- First-class MCP server, file-based state in `.sdd/`, quality gates, cost tracking with budgets, plan files, multi-repo, headless CI

Inserted alphabetically before CrewAI.

Disclosure: I am the maintainer of Bernstein. Submission is factual; happy to revise if anything reads as marketing.