### PR TITLE
Add UGCFast to Video Generation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1582,6 +1582,7 @@ This list includes a range of tools for AI-powered video generation, offering ca
 - [ClipSpeedAI](https://clipspeed.ai) - AI-powered video clipping that automatically finds and extracts the best highlight moments from long-form videos for streamers and content creators.
 - [Shortodella](https://shortodella.com) - AI graphics platform with a canvas editor for image generation, video creation, chat-based editing, and background removal. Free tier available.
 - [HeyVid](https://heyvid.ai) - All-in-one AI video and image generator.
+- [UGCFast](https://ugcfast.ai) - AI UGC video ad generator with 300+ AI actors and 35+ languages, built for performance marketers shipping TikTok, Reels, and Meta ads.
 
 ---
 


### PR DESCRIPTION
Adds UGCFast at the end of the Video Generation Tools list (after HeyVid). UGCFast is an AI UGC video ad generator with 300+ AI actors and 35+ languages, used by performance marketers and DTC brands shipping TikTok, Reels, and Meta video ads. Single line addition; no other changes.

Please complete the sections below. Submissions missing key details may be closed.

---

## Submission Summary

**Tool name:**  
**URL:**  

**Your connection to the tool:**  
<!-- none / creator / contributor / user / other -->

**AI involvement in this submission:**  
<!-- none / some assistance / mostly generated -->

---

## Details

### What does it do?
<!-- Short, clear explanation -->

### Why should it be included?
<!-- What makes it useful or different -->

### Is it publicly available and usable right now?
- [ ] Yes
- [ ] No

---

## Final checks

- [ ] I checked for duplicates
- [ ] I added it to the correct category
- [ ] I used the required format
- [ ] The description is short and neutral

---

### Transparency note 

If this submission was prepared using AI tools or automated agents, feel free to mention it briefly.  
Clear and honest submissions help keep the list high quality.
