### PR TITLE
Add Letterfork (newsletter → 7 platform-native posts in writer voice)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,6 +1227,7 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 - [Resumemind](https://resumemind.com) - An AI-powered resume builder and visual analyzer specifically tailored for software engineers.
 - [MindMap AI](https://mindmapai.app/text-summarizer) - AI-powered tool for transforming text, documents, and research into structured visual mind maps for idea organization, content planning, and knowledge management.
 - [AI Dictation](https://aidictation.com/) - macOS speech-to-text app with auto-switching offline/online recognition and AI-based grammar and filler-word cleanup.
+- [Letterfork](https://letterfork.com) - AI rewrites a newsletter into 7 platform-native social posts (LinkedIn, X, Bluesky, Substack Notes, Threads, Instagram, Reddit) in your own writing voice. Voice cloning learns from your past writing; no auto-publishing.
 
 
 ---


### PR DESCRIPTION
Adds Letterfork to the **🆕 Additional AI and Productivity Tools** section.

**What it is**: AI rewriter for newsletter writers — paste a Substack / Beehiiv / Ghost URL or raw text and get 7 platform-native social posts (LinkedIn, X, Bluesky, Substack Notes, Threads, Instagram, Reddit) in the writer's own voice in ~60 seconds.

**Why it's notable in this list**:
- Voice-cloning learns from the writer's own past content, so outputs sound like the writer rather than generic LLM defaults.
- Each output respects platform-specific writing rules (LinkedIn hook-led with single-sentence paragraphs; Bluesky 300-char chains without "🧵 1/" thread tics; Notes ending in a stance or question; Reddit in member-not-marketer tone).

**Pricing**: Freemium — Free tier (3 lifetime rewrites, all 7 platforms, no credit card), Starter $9/mo, Pro $19/mo, Unlimited $39/mo.

**Live URL**: https://letterfork.com