### PR TITLE
Add Parse to SEO related tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1989,6 +1989,7 @@ This section covers some of the most advanced software platforms for working wit
 ---
 ## SEO related tools
 - If your tool is related to SEO feel free to insert it here
+- **[Parse](https://parse.gl/)** - AI visibility analytics for tracking brand mentions, competitors, and cited sources across ChatGPT and Google AI Overviews.
 - **[PromptEden](https://www.prompteden.com)** - AEO (Answer Engine Optimization) monitoring. Tracks how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand and which competitors they recommend instead, across 9+ AI platforms refreshed daily.
 
 - [AI Visibility Monitor](https://github.com/WorkSmartAI-alt/ai-visibility-monitor) - Open-source Python toolkit that tracks whether ChatGPT, Claude, and Perplexity cite your site. MIT license, runs locally on your credentials.
@@ -2001,4 +2002,3 @@ This section covers some of the most advanced software platforms for working wit
     <img src="https://api.star-history.com/chart?repos=eudk/awesome-ai-tools&type=date&legend=top-left" alt="Star History Chart" />
   </a>
 </p>
-


### PR DESCRIPTION
Adds Parse to the `SEO related tools` section.

Parse tracks brand mentions, competitors, and cited sources across ChatGPT and Google AI Overviews.