### PR TITLE
Add MeMakie AI Tools Index to New and Emerging

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,7 @@ Beyond the GitHub pack, major cloud providers have their own programs for studen
 
 This section introduces the latest AI tools that are gaining popularity and have not yet been widely featured in existing lists. Some of them very new
 
+- **[MeMakie AI Tools Index](https://memakie.com/tools)** - (USA) Editorial directory of 1,300+ AI chat, character, voice, image, and writing tools. Listings are fully automated via a two-LLM curation pipeline (Llama drafts, Claude reviews and rewrites flagged ones). Free, no signup; includes verdicts, screenshots, and pros/cons per tool.
 - **[Clawdbot/Moltbot (clawd.bot)](https://clawd.bot/)** - A self-hosted AI agent that connects to messaging apps (e.g., Telegram/Discord) and can be extended with skills to automate personal workflows like notes, reminders, and task triage.
 - **[Figure AI](https://www.figure.ai/)** - (USA) A robotics company building general-purpose humanoid robots. Backed by major tech players like OpenAI and Microsoft, they are at the forefront of AI embodiment.
 - **[Cognition Labs](https://www.cognition-labs.com/)** - (USA) Creators of **Devin**, the first AI software engineer agent, designed to autonomously handle complex coding tasks from start to finish.


### PR DESCRIPTION
Adding MeMakie's AI Tools Index — an editorial directory of 1,300+ AI tools across chat, character, voice, image, video, writing, and agents categories.

What makes it different: listings are produced by a fully-automated two-LLM curation pipeline. Llama 3.3 70B drafts each entry from a Playwright scrape of the tool's homepage; Claude Haiku reviews and flags ~35% as needing rewrite; Claude Sonnet independently re-scrapes flagged tools and either rewrites or declines if it disagrees with the editor. Different models = different blindspots, so the second pass actually does work.

Each listing has an editorial verdict, feature flags (memory / voice / group chat / NSFW policy), pricing, and a homepage screenshot. Free to browse, no signup. Submission form open with the same automated moderation.

Fits well in the 'New and Emerging' section — it's a recent build, fully automated curation is a novel angle, and it complements rather than competes with this list (different audience, different format).