### PR TITLE
Add Awesome AI Startups to AI Tool Resources & Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1985,6 +1985,7 @@ This section covers some of the most advanced software platforms for working wit
 - **[StackBuilt](https://stackbuilt.co)** - Curated AI tool stacks and honest reviews for solopreneurs. No sponsored content, just tools that work.
 - **[FastChat](https://github.com/lm-sys/FastChat)** - An open-source chat framework that supports running and fine-tuning large language models, including LLaMA, Vicuna, and other popular options. FastChat can be deployed locally for private, controlled conversational AI applications.
 - **[Slate](https://slateup.ai)** – AI-powered interactive learning platform. Generate a course on any topic and learn with AI classmates who ask questions, test your understanding, and adapt to your pace.
+- **[Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups)** - A curated list of bootstrapped, pre-seed, and angel-funded AI products built by independent founders.
 
 ---
 ## SEO related tools


### PR DESCRIPTION
Adds [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) to the **AI Tool Resources & Directories** section.

It's a curated list of indie-built AI startups — bootstrapped, pre-seed, and angel-funded products only — covering 18 categories (AI Agents, Coding, Marketing, Audio/Voice, Image/Design, etc.) with ~440 entries.

Followed contributing conventions: matched the section's existing entry format and added at the bottom of the section.