### PR TITLE
Add OpenClaw Consensus API + Web Classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,6 +1092,8 @@ OpenClaw is an open-source personal AI assistant/agent that can run locally and 
 - **[openclaw/lobster](https://github.com/openclaw/lobster)** — Workflow shell / macro engine  
 
 - **[Product Manager Skills](https://github.com/Digidai/product-manager-skills)** — PM-focused skill pack  
+- **[OpenClaw Consensus API](https://www.yanmiayn.com/api/)** — Multi-LLM voting API that returns a disagreement score across providers (OpenAI, Anthropic, Google, etc.) for the same prompt  
+- **[OpenClaw Consensus Web Classifier](https://apify.com/yanmiayn/consensus-web-classifier)** — Apify actor for bulk URL categorization via 6-LLM voting, with confidence + dissent fields  
 
 
 ### Deployment & Infrastructure


### PR DESCRIPTION
Adds two production tools to the existing OpenClaw Ecosystem -> Ecosystem & Extensions section.

**OpenClaw Consensus API** (https://www.yanmiayn.com/api/) — REST API that fans the same prompt out to multiple LLM providers (OpenAI, Anthropic, Google, Mistral, Cohere) and returns each response plus a disagreement score. Useful for hallucination detection and routing high-risk prompts.

**OpenClaw Consensus Web Classifier** (https://apify.com/yanmiayn/consensus-web-classifier) — Apify actor for bulk URL categorization using 6-LLM voting. Returns category, confidence, and dissent per row.

Both are publicly accessible and usable now. Disclosure: I am the author. Submission prepared with AI assistance per CONTRIBUTING.md transparency note.
