### PR TITLE
Add AnySlide - AI slide deck generator with CJK rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ This section introduces the latest AI tools that are gaining popularity and have
 - **[AgentReady](https://agentready.site)** - AI readiness scanner that scores any website on 8 factors (llms.txt, ai.txt, schema markup, MCP protocol, bot accessibility, and more). Provides actionable recommendations, industry benchmarks, and a free public API for AI agent compatibility scoring.
 - **[KeepRule](https://keeprule.com)** - AI-powered investment discipline platform that tracks principles from 26 legendary investors including Buffett, Munger, and Dalio. Features scenario analysis, psychological tests, and personalized investment coaching.
 - **[toprank](https://github.com/nowork-studio/toprank)** - Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Pulls real Google Search Console, PageSpeed Insights, and Google Ads API data, audits traffic and wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, and ships the fixes directly to source or CMS (WordPress, Strapi, Contentful, Ghost).
+- **[AnySlide](https://anyslide.app)** - AI slide deck generator with two engines: HTML inline-editable web slides and gpt-image-2 full-image rendering with native Chinese, Japanese, and Korean text support. 38 templates, 8 niche presets, 60 free credits at signup.
 
 ---
 


### PR DESCRIPTION
Hi! Adding **AnySlide** to the `🆕 New and Emerging AI Tools` section, alongside other slide / presentation tools like Beautiful.ai and Tome AI.

### What it is
An AI slide deck generator that turns an article, link, or PDF into a full presentation in ~30 seconds. Two rendering engines:

- **HTML path** — outputs inline-editable web slides (reveal.js / Slidev style)
- **gpt-image-2 path** — renders each page as a full image with **native Chinese / Japanese / Korean text**, which solves the garbled-CJK problem most AI image tools have with non-Latin scripts

### Qualifies per CONTRIBUTING
- ✅ Public site, no waitlist
- ✅ Functional and usable today
- ✅ 60 free credits at signup, no credit card required
- ✅ Live URL: https://anyslide.app

### Disclosure
I'm the maker of AnySlide — filing this myself because the CJK-rendering angle isn't represented elsewhere in the list, and I think it'd be a useful complement to the existing slide tools in this section.

Thanks for maintaining the list!