### PR TITLE
Add Industry-Specific AI Directories section with The Agentic Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1992,7 +1992,9 @@ This section covers some of the most advanced software platforms for working wit
 - **[PromptEden](https://www.prompteden.com)** - AEO (Answer Engine Optimization) monitoring. Tracks how ChatGPT, Claude, Gemini, Perplexity, Copilot, and Grok describe your brand and which competitors they recommend instead, across 9+ AI platforms refreshed daily.
 
 - [AI Visibility Monitor](https://github.com/WorkSmartAI-alt/ai-visibility-monitor) - Open-source Python toolkit that tracks whether ChatGPT, Claude, and Perplexity cite your site. MIT license, runs locally on your credentials.
+## Industry-Specific AI Directories
 
+- [The Agentic Index](https://theagenticindex.com) — AI tools directory organized by 17 skilled trades (plumbing, HVAC, electrical, roofing, landscaping, etc.). Each trade page lists tools fit to that trade's workflow. Free, ad-free, affiliate-supported.
 ---
 ## New Github Projects
 ---


### PR DESCRIPTION
Adds a new section "Industry-Specific AI Directories" with The Agentic Index as the first entry. The Agentic Index sorts AI tools by skilled trade rather than by tool category — a gap not covered by existing tool-focused entries.

---

## Submission Summary

**Tool name:** The Agentic Index

**URL:** https://theagenticindex.com

**Your connection to the tool:** creator (I built and operate the directory)

**AI involvement in this submission:** The site is a curated directory of AI tools, not an AI-generated tool. This PR description was written by me; no AI-generated testimonials or fabricated content on the site itself. Tool listings are editorially independent of any AI generation.

**Why this tool fits the list:** This list is "Comprehensive List of AI Tools" and includes tool directories. The Agentic Index fills a niche the existing entries don't cover — a directory organized by skilled trade (plumbing, HVAC, electrical, roofing, landscaping, etc. — 17 trades total) rather than by tool category. Each trade page lists tools that fit that trade's actual workflow (dispatch, on-site quoting, route optimization, review collection), not generic SaaS. Free to browse, ad-free, affiliate-supported with disclosure on every page.

**Format compliance:**
- New section heading uses `## ` (h2) consistent with other sections
- - Entry uses standard markdown link format
- - Description is one sentence with concrete details
- - No marketing fluff