### PR TITLE
Add TinyTools entries to Additional AI and Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1223,6 +1223,10 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 - [Resumemind](https://resumemind.com) - An AI-powered resume builder and visual analyzer specifically tailored for software engineers.
 - [MindMap AI](https://mindmapai.app/text-summarizer) - AI-powered tool for transforming text, documents, and research into structured visual mind maps for idea organization, content planning, and knowledge management.
 - [AI Dictation](https://aidictation.com/) - macOS speech-to-text app with auto-switching offline/online recognition and AI-based grammar and filler-word cleanup.
+- [TinyTools](https://tinytools-smoky.vercel.app/) - Free single-purpose web utilities (favicon generator, OG image generator, SEO meta tag generator, color palette, domain name generator). All browser-based, no signup. Open source.
+- [TinyTools Background Remover](https://tinytools-smoky.vercel.app/background-remover/) - AI background removal that runs entirely in the browser via ONNX/WASM. No upload, no signup.
+- [TinyTools AI Cost Calculator](https://tinytools-smoky.vercel.app/ai-cost-calculator/) - Free in-browser calculator for estimating LLM/API costs across providers.
+- [TinyTools AI Disclosure Generator](https://tinytools-smoky.vercel.app/ai-disclosure-generator/) - Generates AI content disclosures (EU AI Act compliant). Free, no signup.
 
 
 ---


### PR DESCRIPTION
Hi! Adding [TinyTools](https://tinytools-smoky.vercel.app/) to the Additional AI and Productivity Tools section.

TinyTools is a collection of free, single-purpose web utilities that run entirely in the browser — no signup, no server uploads. Open source. The AI-related entries are:

- TinyTools — main entry covering several utilities (favicon, OG image, SEO meta tags, color palette, domain name).
- TinyTools Background Remover — runs ONNX/WASM locally in the browser; images never leave the device.
- TinyTools AI Cost Calculator — estimates LLM/API costs across providers.
- TinyTools AI Disclosure Generator — generates AI content disclosures (EU AI Act compliant).

I am the maintainer of TinyTools. All tools are publicly accessible and functional today. Thanks for considering!