### PR TITLE
docs: add Lervos to AI-Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,7 @@ This section covers the latest AI-driven robots, ranging from quadruped robotic 
 - [bugfree.ai](https://bugfree.ai/) - bugfree.ai is an advanced AI-powered platform designed to practice and prepare for system design and behavioral interviews.
 - [manifest.build](https://manifest.build/) - The backend AI can generate, developers can trust!
 - [Learnly AI](https://learnlyai.co.uk/) - AI-powered academic assistant for students with note-taking, essay writing, and presentation generation.
+- [Lervos](https://lervos.com) - AI-powered proposal assistant for freelancers, built on Hono, Cloudflare Workers, and D1.
 - [Domain Generator](https://freedomaingenerator.com/) - Free AI domain generator with availability check and price comparison
 - [Iteration Layer](https://iterationlayer.com) - Composable content processing APIs for document extraction, image transformation, and image, document & sheet generation.
 - [Free AI Tools JP](https://free-ai-tools.jp) - Curated directory of 63 free AI tools for Japanese users (text generation, image generation, transcription, contract review), no signup required.


### PR DESCRIPTION
# Pull Request Guidelines

Please complete the sections below. Submissions missing key details may be closed.

> PR reviews may take up to 1 month depending on backlog and activity.  
> Low-effort or incorrectly formatted submissions may be closed without maintainer edits.

---

## Submission Summary

**Tool name:** Lervos  
**URL:** https://lervos.com

**Your connection to the tool:** creator

**AI involvement in this submission:** some assistance

---

## Details

### What does it do?

Lervos is an AI-powered proposal assistant for freelancers. It helps automate drafting **professional project bids** so users spend less time on repetitive proposal work (“proposal fatigue”) while keeping tone and structure consistent. It is built as production SaaS on a **serverless stack**: **Hono**, **Cloudflare Workers**, and **D1**.

### Why should it be included?

The **AI-Related Tools** section already lists domain-specific assistants (e.g. copywriting, sales, academic writing). Lervos fits as a **business-writing-focused** tool aimed at **proposals and bids** rather than generic chat. For technical readers, it is also a concrete example of **Hono + Cloudflare Workers + D1** in a real product.

### Is it publicly available and usable right now?

- [x] Yes
- [ ] No

---

## Final checks

- [x] I checked for duplicates
- [x] I added it to the correct category (**🤖 AI-Related Tools**)
- [x] I used the required format (`- [Name](URL) - description`)
- [x] The description is short and neutral

---

### Transparency note

The README one-liner and parts of this PR description were refined with help from an AI assistant. Product facts and stack (Hono, Cloudflare Workers, D1) are accurate.
