### PR TITLE
Add invisible-playwright to AI Agent Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1180,6 +1180,7 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 - **[AI Dev Jobs](https://aidevboard.com)** — Structured data on 8,400+ active AI/ML engineering jobs from 580 ATS sources (Anthropic, OpenAI, Meta FAIR, DeepMind, etc.). Free REST API + MCP server at `aidevboard.com/mcp`. Useful for agents doing AI job market research or helping users find roles.
 - **[nhs-score-check-action](https://github.com/unitedideas/nhs-score-check-action)** — GitHub Action that fetches your site's agentic readiness score via Not Human Search and fails CI if the score drops. Protects against regressions in your agent-facing surface. MIT.
 - **[Mira](https://github.com/vwww-droid/Mira)** — AI-assisted runtime protection analysis platform for third-party Android and iOS apps, enabling agents to use host-app-side shell, Java, Native, and Frida capabilities for environment risk detection and hardening validation.
+- **[invisible-playwright](https://github.com/feder-cr/invisible_playwright)** — Python wrapper for a stealth-patched Firefox 150 binary. Drop-in replacement for vanilla Playwright Firefox, returns a native Playwright Browser. Anti-fingerprinting at the C++ source level (Canvas, WebGL, AudioContext, Fonts, WebRTC, Timezone, DevTools detection). Useful when AI agents need anti-detect web access. MIT.
 ---
 ## 🆕 Additional AI and Productivity Tools
 


### PR DESCRIPTION
Python wrapper for a stealth-patched Firefox 150 binary. Returns a native Playwright Browser, so any agent code already on Playwright runs unchanged. Anti-detect spoofing is in the C++ source (15 patches), useful for agents that need to scrape sites guarded by reCAPTCHA v3 / FingerprintPro without falling back to a SaaS browser.

Repo: https://github.com/feder-cr/invisible_playwright
Patches: https://github.com/feder-cr/firefox-stealth