### PR TITLE
Add traceAI and ai-evaluation to LLM Ops section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1888,6 +1888,8 @@ A selection of platforms offering API integration for various AI applications an
 - [Embedding Similarity Calculator](https://uatgpt.com/tools/embedding-similarity/) - Compute cosine, dot, Euclidean, Manhattan, and Hamming similarity between two vectors, with ANN algorithm recommendation (FLAT / HNSW / IVF+PQ) matched to corpus scale and recall targets.
 - [Credyt](https://credyt.ai) - Real-time monetization infrastructure for AI-native products. Credyt combines cost and profitability observabilty with usage-based monetization and a managed customer billing UX.
 - [KubeStellar Console](https://github.com/kubestellar/console) - Open-source multi-cluster Kubernetes dashboard with an MCP server (kc-agent) that enables AI coding agents to query and manage clusters via natural language. Integrates with 20+ CNCF projects for AI-assisted operations across edge and cloud.
+- [traceAI](https://github.com/future-agi/traceAI) - Open-source OpenTelemetry-native tracing framework for LLM and AI agent applications. Auto-instruments 20+ frameworks (OpenAI, Anthropic, LangChain, LlamaIndex, CrewAI, Bedrock).
+- [ai-evaluation](https://github.com/future-agi/ai-evaluation) - Open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge, guardrail scanners (jailbreak, PII, injection), and AutoEval pipelines with CI/CD support.
 ---
 
 ## 🛠️ REPOS


### PR DESCRIPTION
## Summary
- Adds [traceAI](https://github.com/future-agi/traceAI) — OpenTelemetry-native tracing framework for LLM/agent apps
- Adds [ai-evaluation](https://github.com/future-agi/ai-evaluation) — LLM evaluation framework with 50+ metrics, LLM-as-Judge, and guardrail scanners

Both added to the LLM Ops section alongside Helicone AI and Keywords AI.