### PR TITLE
Add KDP Readiness Score to AI & Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,6 +1227,7 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 - [Resumemind](https://resumemind.com) - An AI-powered resume builder and visual analyzer specifically tailored for software engineers.
 - [MindMap AI](https://mindmapai.app/text-summarizer) - AI-powered tool for transforming text, documents, and research into structured visual mind maps for idea organization, content planning, and knowledge management.
 - [AI Dictation](https://aidictation.com/) - macOS speech-to-text app with auto-switching offline/online recognition and AI-based grammar and filler-word cleanup.
+- [KDP Readiness Score](https://publishing.co.uk/audit/kdp-readiness/) - Free 60-second pre-flight audit for indie authors. Runs the 30+ technical checks Amazon's KDP review system uses (margins, bleed, font embedding, image DPI, ToC integrity, ISBN match, EPUB validity) and returns a score plus remediation PDF. No signup. Disclosure: submitted by the maker.
 
 
 ---


### PR DESCRIPTION
Adds [KDP Readiness Score](https://publishing.co.uk/audit/kdp-readiness/) to the "Additional AI and Productivity Tools" section.

**What it is:** A free 60-second pre-flight audit for self-publishing authors. The tool runs the 30+ technical checks Amazon's KDP review system uses against a manuscript PDF (margins, bleed, font embedding, image DPI, ToC integrity, ISBN match, EPUB validity) and returns a score out of 100 plus a remediation PDF.

**Why it fits:** The category already includes Grammarly, Notion AI, Otter.ai, and similar productivity tools for writers and professionals. KDP Readiness Score sits cleanly alongside these as a niche productivity tool for indie authors.

**Public + functional:** Live since April 2026, no signup or paywall on the diagnostic itself.

**Disclosure:** Per the CONTRIBUTING.md transparency note — I'm the maker (founder of publishing.co.uk). Happy to remove if maintainers prefer to keep the list third-party only.