### PR TITLE
Add ClipRocket Studio to AI-Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,7 @@ This section covers the latest AI-driven robots, ranging from quadruped robotic 
 - [Iteration Layer](https://iterationlayer.com) - Composable content processing APIs for document extraction, image transformation, and image, document & sheet generation.
 - [Free AI Tools JP](https://free-ai-tools.jp) - Curated directory of 63 free AI tools for Japanese users (text generation, image generation, transcription, contract review), no signup required.
 - [Free Tegami Tools JP](https://free-tegami-tools.jp) - 65 AI tools for Japanese ceremonial and business writing (wedding speeches, eulogies, new-year greetings, business correspondence).
+- [ClipRocket Studio](https://cliprocketstudio.com) - Hebrew-first AI tool that turns long-form video podcasts into vertical short clips for YouTube Shorts, TikTok, and Reels with burned-in Hebrew captions.
 
 ---
 ## 🦞 OpenClaw Ecosystem


### PR DESCRIPTION
# Pull Request Guidelines

## Submission Summary

**Tool name:** ClipRocket Studio  
**URL:** https://cliprocketstudio.com  

**Your connection to the tool:** creator  

**AI involvement in this submission:** some assistance (used an AI coding assistant to draft the entry and PR text)  

---

## Details

### What does it do?
ClipRocket Studio is a Hebrew-first AI tool that turns long-form video podcasts into ready-to-publish vertical short clips for YouTube Shorts, TikTok, Instagram Reels, and Facebook Reels. It auto-picks moments, burns in Hebrew captions, and generates Hebrew titles.

### Why should it be included?
Most short-form video AI tools (OpusClip, Vizard, Munch, Klap, SubMagic) treat Hebrew as an afterthought — captions break under RTL, titles come out unusable. ClipRocket is built Hebrew-first, so the captions, title generation, and transcription all work natively in Hebrew. Useful for the Hebrew-speaking podcast / creator audience.

### Is it publicly available and usable right now?
- [x] Yes
- [ ] No

---

## Final checks

- [x] I checked for duplicates
- [x] I added it to the correct category
- [x] I used the required format
- [x] The description is short and neutral

---

### Transparency note
This submission was prepared with help from an AI coding assistant (drafting the entry text and filling in this template). The tool itself, ClipRocket Studio, is built and operated by a human (Dov).
