### PR TITLE
Add AI Models Catalog — structured catalog of 4,587+ AI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1983,6 +1983,7 @@ This section covers some of the most advanced software platforms for working wit
 ## AI Tool Resources & Directories
 
 - **[StackBuilt](https://stackbuilt.co)** - Curated AI tool stacks and honest reviews for solopreneurs. No sponsored content, just tools that work.
+- **[AI Models Catalog](https://github.com/i-need-token/ai-models)** - Structured YAML catalog of 4,587+ AI models across 95 providers with pricing, context windows, modalities, and capabilities. First-party data with TypeScript types, Zod validation, interactive comparison tool, and 17 SEO pages for model discovery.
 - **[FastChat](https://github.com/lm-sys/FastChat)** - An open-source chat framework that supports running and fine-tuning large language models, including LLaMA, Vicuna, and other popular options. FastChat can be deployed locally for private, controlled conversational AI applications.
 - **[Slate](https://slateup.ai)** – AI-powered interactive learning platform. Generate a course on any topic and learn with AI classmates who ask questions, test your understanding, and adapt to your pace.
 


### PR DESCRIPTION
## AI Models Catalog

A structured YAML catalog of AI models from 95 providers, with pricing, context windows, modalities, and capabilities. All data sourced from first-party APIs.

**What makes it useful:**
- **4,587+ models across 95 providers** — OpenAI, Anthropic, Google, Meta, DeepSeek, Alibaba, Mistral, xAI, and 88 more
- **First-party data only** — every data point comes from the provider's own API or documentation
- **Machine-readable YAML** with TypeScript types + Zod validation
- **Interactive catalog** — search, filter, compare models with price calculator and model picker
- **17 SEO comparison pages** — Best Models, Free Models, LLM Pricing, OpenAI Alternatives, etc.
- **Free to use** — 81 free models with tool calling, reasoning, and vision
- **npm package** — `npm install ai-models`
- **GitHub Action** — use model data in CI/CD workflows

**Links:**
- Repository: https://github.com/i-need-token/ai-models
- Interactive Catalog: https://i-need-token.github.io/ai-models/
- Free Models: https://i-need-token.github.io/ai-models/free-ai-models.html
- LLM Pricing: https://i-need-token.github.io/ai-models/llm-pricing.html

Added to the **AI Tool Resources & Directories** section.