### PR TITLE
docs: remove broken OpenClaw skills link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,6 @@ OpenClaw is an open-source personal AI assistant/agent that can run locally and 
 ### Ecosystem & Extensions
 - **[ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw)** – Lightweight autonomous agent framework  
 - **[ClawHub](https://github.com/openclaw/clawhub)** — Skill directory  
-- **[openclaw/skills](https://github.com/openclaw/skills)** — Archived skills  
 - **[openclaw/lobster](https://github.com/openclaw/lobster)** — Workflow shell / macro engine  
 
 - **[Product Manager Skills](https://github.com/Digidai/product-manager-skills)** — PM-focused skill pack  


### PR DESCRIPTION
## Problem
Issue #280 reports that the OpenClaw ecosystem section links to `openclaw/skills`, which no longer resolves on GitHub.

## Solution
Remove that dead archived-skills entry while keeping the adjacent active OpenClaw ecosystem links (ClawHub and lobster) intact.

## Validation
- `gh repo view openclaw/skills` confirms GitHub cannot resolve the repository.
- Verified `https://github.com/openclaw/skills` no longer appears in `README.md`.
- Ran `git diff --check`.

## Confidence
85/100 — lower-risk docs/broken-link cleanup directly tied to issue #280.
