### PR TITLE
Add Gemini Omni Prompts to AI Tool Resources & Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1985,6 +1985,7 @@ This section covers some of the most advanced software platforms for working wit
 - **[StackBuilt](https://stackbuilt.co)** - Curated AI tool stacks and honest reviews for solopreneurs. No sponsored content, just tools that work.
 - **[FastChat](https://github.com/lm-sys/FastChat)** - An open-source chat framework that supports running and fine-tuning large language models, including LLaMA, Vicuna, and other popular options. FastChat can be deployed locally for private, controlled conversational AI applications.
 - **[Slate](https://slateup.ai)** – AI-powered interactive learning platform. Generate a course on any topic and learn with AI classmates who ask questions, test your understanding, and adapt to your pace.
+- **[Gemini Omni Prompts](https://geminiomniprompts.org/)** - Source-cited prompt library for Google's Gemini Omni video model. Free, no signup.
 
 ---
 ## SEO related tools


### PR DESCRIPTION
## What this adds

Adds [Gemini Omni Prompts](https://geminiomniprompts.org/) — a free, source-cited prompt library for Google's Gemini Omni video model (released May 2026).

## Why it might fit here

Every prompt is adapted from a verifiable source rather than AI-guessed:
- DeepMind's official prompt guide (e.g. the mirror-ripple, butterfly→bee, bubble sculpture demos)
- Hands-on testing from PixVerse, Atlas Cloud, Chrome Unboxed, and Medium's "Gemini Omni Prompt Playbook"

There's also a field guide covering Omni's prompt formula, camera vocabulary it explicitly parses, duration sweet spots per use case, and known failure modes Google's docs don't surface (text rendering, hand articulation, multi-shot consistency, prompt length).

No login, no API key, no upsell. Static site (Astro + Cloudflare Pages).

## Checklist

- [x] One link per PR
- [x] Placed under the most relevant existing category (AI Tool Resources & Directories)
- [x] Format matches surrounding entries