### PR TITLE
Add HandyAI to New and Emerging AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ This section introduces the latest AI tools that are gaining popularity and have
 - **[AgentReady](https://agentready.site)** - AI readiness scanner that scores any website on 8 factors (llms.txt, ai.txt, schema markup, MCP protocol, bot accessibility, and more). Provides actionable recommendations, industry benchmarks, and a free public API for AI agent compatibility scoring.
 - **[KeepRule](https://keeprule.com)** - AI-powered investment discipline platform that tracks principles from 26 legendary investors including Buffett, Munger, and Dalio. Features scenario analysis, psychological tests, and personalized investment coaching.
 - **[toprank](https://github.com/nowork-studio/toprank)** - Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Pulls real Google Search Console, PageSpeed Insights, and Google Ads API data, audits traffic and wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, and ships the fixes directly to source or CMS (WordPress, Strapi, Contentful, Ghost).
+- **[HandyAI](https://handyai.tools)** – Free single-purpose tools for LLM developers: a token counter and an API cost calculator across Claude, GPT, and Gemini. Runs client-side, no signup.
 
 ---
 


### PR DESCRIPTION
Added **HandyAI** to the **New and Emerging AI Tools** section.

## Submission Summary

**Tool name:** HandyAI
**URL:** https://handyai.tools

**Your connection to the tool:** creator

**AI involvement in this submission:** some assistance — an AI agent helped browse, draft, and format this PR; the entry and this description were reviewed before submitting.

---

## Details

### What does it do?
HandyAI is a small set of free, single-purpose web tools for people who build with LLMs. Two are live: a token counter that shows counts for Claude, GPT, and Gemini side by side, and an API cost calculator that projects monthly spend for a workload across the same providers, including cached-input pricing.

### Why should it be included?
It fits this section alongside focused single-purpose AI utilities like RegexAI and CronAI. Everything runs client-side — input never leaves the browser — with no signup and no ads.

### Is it publicly available and usable right now?
- [x] Yes
- [ ] No

---

## Final checks

- [x] I checked for duplicates
- [x] I added it to the correct category
- [x] I used the required format
- [x] The description is short and neutral

---

### Transparency note

This submission was prepared with help from an AI agent (browsing and drafting). The information is accurate and was reviewed before opening the PR.