### PR TITLE
Add Nomenco to New and Emerging AI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,6 +837,7 @@ Beyond the GitHub pack, major cloud providers have their own programs for studen
 This section introduces the latest AI tools that are gaining popularity and have not yet been widely featured in existing lists. Some of them very new
 
 - **[Clawdbot/Moltbot (clawd.bot)](https://clawd.bot/)** - A self-hosted AI agent that connects to messaging apps (e.g., Telegram/Discord) and can be extended with skills to automate personal workflows like notes, reminders, and task triage.
+- **[Nomenco](https://nomenco.com/)** - (France/EU) AI-powered company naming tool for founders. Generates candidates against a structured brief, filters .com availability upstream, runs US + EU trademark knockout against USPTO + EUIPO, and outputs a shortlist with full brand direction (positioning, tone of voice, archetype, ten-year risk assessment).
 - **[Figure AI](https://www.figure.ai/)** - (USA) A robotics company building general-purpose humanoid robots. Backed by major tech players like OpenAI and Microsoft, they are at the forefront of AI embodiment.
 - **[Cognition Labs](https://www.cognition-labs.com/)** - (USA) Creators of **Devin**, the first AI software engineer agent, designed to autonomously handle complex coding tasks from start to finish.
 - **[Luma Labs](https://lumalabs.ai/dream-machine)** - (USA) Creator of **Dream Machine**, a publicly accessible and highly popular text-to-video model that generates high-quality, coherent video clips.


### PR DESCRIPTION
## Summary

Adds **[Nomenco](https://nomenco.com/)** to the **New and Emerging AI Tools** section.

Nomenco is an AI-powered company-naming tool aimed at pre-incorporation founders. It runs a structured naming brief, generates candidates across five naming territories, pre-filters for .com availability before names ever reach the user, then runs US and EU trademark knockout against the USPTO and EUIPO databases. Output is a shortlist of three to five names with a full brand direction (positioning, tone of voice, archetype, ten-year risk assessment).

The product is publicly accessible, functional, and usable today (\$1,900 single tier, self-serve).

## Why it fits

- **High Quality & Established**: production tool with payment flow, not a waitlist or landing page.
- **Real Value Over Hype**: the description is factual (what the tool does, which databases it queries, what the output is). No marketing language.
- **Relevance**: development + creativity tool aimed at founders.
- **No duplicates**: searched the README for "naming", "brand name", "Nomenco" — no overlapping entries.

## Disclosure

I work on Nomenco. Submission was prepared in line with CONTRIBUTING.md (concise, factual, real product, no marketing language).

## Format

Used the existing format:
\`\`\`
- **[Tool Name](URL)** - (Region) Brief, one-line description.
\`\`\`

Placed alphabetically-adjacent to the existing first entry in the section.