### PR TITLE
Add Tapetide (AI stock research for Indian markets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,7 @@ This section introduces the latest AI tools that are gaining popularity and have
 - **[DoaCam](https://doacam.com)** - AI video companion with a 3D avatar that sees you through your camera, talks in real time, and remembers every conversation. Runs in browser.
 - **[AgentReady](https://agentready.site)** - AI readiness scanner that scores any website on 8 factors (llms.txt, ai.txt, schema markup, MCP protocol, bot accessibility, and more). Provides actionable recommendations, industry benchmarks, and a free public API for AI agent compatibility scoring.
 - **[KeepRule](https://keeprule.com)** - AI-powered investment discipline platform that tracks principles from 26 legendary investors including Buffett, Munger, and Dalio. Features scenario analysis, psychological tests, and personalized investment coaching.
+- **[Tapetide](https://tapetide.com)** - AI-first stock research platform for Indian markets. Ask anything about any NSE or BSE stock and get instant, analyst-grade answers with financials, a 326-ratio screener, and FII/DII institutional flows. Includes a public MCP server for AI agents.
 - **[toprank](https://github.com/nowork-studio/toprank)** - Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Pulls real Google Search Console, PageSpeed Insights, and Google Ads API data, audits traffic and wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, and ships the fixes directly to source or CMS (WordPress, Strapi, Contentful, Ghost).
 
 ---


### PR DESCRIPTION
Adds **Tapetide** to the **New and Emerging AI Tools** section, next to KeepRule (a similar AI investing tool).

`- **[Tapetide](https://tapetide.com)** - AI-first stock research platform for Indian markets. Ask anything about any NSE or BSE stock and get instant, analyst-grade answers with financials, a 326-ratio screener, and FII/DII institutional flows. Includes a public MCP server for AI agents.`

Per the contributing guidelines: it's a public, functional product (usable right now, no waitlist), provides clear practical value (research across all 8,200+ NSE & BSE stocks), and isn't a duplicate. Follows the existing bold-link format.