### PR TITLE
Add ViralMint to Video Generation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1550,6 +1550,7 @@ This list includes a range of tools for AI-powered video generation, offering ca
 - [Sora](https://www.sora.com) - AI video generation platform from OpenAI. RIP
 - [Synthesia](https://www.synthesia.io) - AI video generation platform.
 - [RunwayML](https://runwayml.com) - AI toolkit for artists and creators.
+- [ViralMint](https://viralmint.net/) - Open-source desktop app for short-form video: scouts trending videos across YouTube/TikTok/Reddit, clips long-form sources with local Whisper, and generates AI originals (script, voiceover, word-by-word captions, music). AGPL-3.0.
 - [Deep Video Portraits](https://www.graphics.stanford.edu/projects/deepvideo) - AI-driven facial reenactment in videos.
 - [Pictory](https://pictory.ai) - AI-powered video editing and creation.
 - [Lumen5](https://lumen5.com) - AI-driven video maker for businesses.


### PR DESCRIPTION
Adds **ViralMint** to the **Video Generation Tools** section.

ViralMint is an open-source (AGPL-3.0) desktop app for the short-form video workflow: it scouts trending videos across YouTube/TikTok/Reddit, clips long-form sources locally with Whisper, and generates AI originals (script, voiceover, word-by-word captions, background music). Users download the finished mp4 and post it themselves.

- Source: https://github.com/openclaw-easy/ViralMint
- Single entry, placed in **Video Generation Tools**
- Matches the existing `- [Name](url) - description.` format

Thanks for maintaining this list!