### PR TITLE
Add CoderPlan - unified LLM API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1830,7 +1830,8 @@ A selection of platforms offering API integration for various AI applications an
 20. [ChatterOn](https://chatteron.io) - AI chatbot building platform with API.
 21. [YobiYoba](https://www.yobiyoba.com/en/) - The Yobiyoba API provides automatic transcription, real-time processing, audio-text alignment, and lexicon enhancement to enrich your audio transcriptions.
 22. [SkillBoss](https://skillboss.co) - Unified API gateway for 100+ AI models (Claude, GPT, Gemini, DeepSeek) plus image/video generation, payments, and infrastructure services. OpenAI-compatible.
-23. Many others support API integration too
+23. [CoderPlan](https://coderplan.ai) - Unified LLM API gateway for China/APAC. OpenAI-compatible access to Claude, GPT, Gemini, DeepSeek and 50+ models. Pay-as-you-go pricing.
+24. Many others support API integration too
 
 ---
 


### PR DESCRIPTION
Adds CoderPlan to the "Sites with API Integration" section.

**CoderPlan** is a unified LLM API gateway:
- OpenAI-compatible API (`/v1/chat/completions`)
- One-line configuration for Claude Code, Codex CLI, and Gemini CLI
- Supports Claude, GPT-5.5/4o, Gemini 3, DeepSeek, and Qwen models
- Pay-per-use pricing, publicly accessible at https://coderplan.ai

**Contribution notes:**
- No duplicate (Ctrl+F confirmed)
- Follows the existing numbered list format
- Concise, factual description per CONTRIBUTING.md guidelines
- I am the developer of CoderPlan