### PR TITLE
Add DownForAI - AI services status monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,7 @@ This section introduces the latest AI tools that are gaining popularity and have
 - **[AgentReady](https://agentready.site)** - AI readiness scanner that scores any website on 8 factors (llms.txt, ai.txt, schema markup, MCP protocol, bot accessibility, and more). Provides actionable recommendations, industry benchmarks, and a free public API for AI agent compatibility scoring.
 - **[KeepRule](https://keeprule.com)** - AI-powered investment discipline platform that tracks principles from 26 legendary investors including Buffett, Munger, and Dalio. Features scenario analysis, psychological tests, and personalized investment coaching.
 - **[toprank](https://github.com/nowork-studio/toprank)** - Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Pulls real Google Search Console, PageSpeed Insights, and Google Ads API data, audits traffic and wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, and ships the fixes directly to source or CMS (WordPress, Strapi, Contentful, Ghost).
+- **[DownForAI](https://downforai.com)** - Real-time status monitoring for 800+ AI services including ChatGPT, Claude, Gemini, Midjourney, and Groq. Tracks uptime, latency, and community outage reports with a public API and free status badges.
 
 ---
 


### PR DESCRIPTION
Adds DownForAI to the list of AI tools.

DownForAI is a real-time status monitoring service for 800+ AI services and tools including:

- LLM APIs: OpenAI, Anthropic, Google Gemini, Groq, DeepSeek, Mistral
- - Image generation: Midjourney, DALL-E, Stable Diffusion
- - Code AI: GitHub Copilot, Cursor, Codeium
- - And many more
Features:

- Live uptime monitoring across multiple endpoints per provider
- - Latency tracking (p50/p95)
- - Community outage reports
- - Public status API
- - Free SVG status badges
I noticed the list already includes similar monitoring tools, so DownForAI fits well in the same category. Happy to adjust placement or wording if preferred.