### PR TITLE
feat: add TWZRD Agent Intel MCP server to AI Agent Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1281,6 +1281,7 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 - **[Mira](https://github.com/vwww-droid/Mira)** — AI-assisted runtime protection analysis platform for third-party Android and iOS apps, enabling agents to use host-app-side shell, Java, Native, and Frida capabilities for environment risk detection and hardening validation.
 - **[invisible-playwright](https://github.com/feder-cr/invisible_playwright)** — Python wrapper for a stealth-patched Firefox 150 binary. Drop-in replacement for vanilla Playwright Firefox, returns a native Playwright Browser. Anti-fingerprinting at the C++ source level (Canvas, WebGL, AudioContext, Fonts, WebRTC, Timezone, DevTools detection). Useful when AI agents need anti-detect web access. MIT.
 - **[agent-qa](https://github.com/vostride/agent-qa)** — Self-improving agentic QA harness with memory for natural-language web and mobile test execution.
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** — On-chain trust scoring and identity verification for AI agents on Solana. MCP server (`intel.twzrd.xyz/mcp`) exposes `score_agent(wallet)` and `preflight_check(wallet)` free tools for agent reputation checks, and `get_trust_receipt(wallet)` (HTTP 402 micropayment) for a signed on-chain proof of agent identity and behavior history. Useful for multi-agent systems that need to verify peer-agent trustworthiness before delegating tasks or funds.
 ---
 ## 🆕 Additional AI and Productivity Tools
 


### PR DESCRIPTION
## TWZRD Agent Intel

**URL**: https://intel.twzrd.xyz
**MCP endpoint**: https://intel.twzrd.xyz/mcp (streamable-http, MCP 2025-03-26)

TWZRD Agent Intel is an on-chain trust scoring and identity verification service for AI agents on Solana. It exposes an MCP server with three tools:

- `score_agent(wallet)` — free; returns on-chain reputation score, activity history, and trust signals for any agent wallet
- `preflight_check(wallet)` — free; checks whether an agent wallet is safe to interact with before delegating tasks or funds
- `get_trust_receipt(wallet)` — paid via HTTP 402 micropayment (USDC on Solana); returns a signed, verifiable on-chain proof of agent identity and behavior history

**Why it belongs in AI Agent Tools**: Multi-agent systems increasingly need to verify peer-agent trustworthiness before delegating tasks, sharing context, or transferring funds. TWZRD provides the infrastructure layer for agent-to-agent trust checks — queryable via MCP by any MCP-compatible agent runtime.

**MCP config**:
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

Fits alongside Agentprobe, Hlido, and Not Human Search — other trust/verification MCP tools already in this section.