### PR TITLE
feat: add ProposalCraft to Additional AI and Productivity Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1334,6 +1334,7 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 - [Aurcue](https://www.aurcue.com) - AI personal aesthetic assistant that turns one photo into practical guidance for colors, outfits, hairstyles, glasses, and daily style decisions.
 
 - [Letterfork](https://letterfork.com) - AI rewrites a newsletter into 7 platform-native social posts (LinkedIn, X, Bluesky, Substack Notes, Threads, Instagram, Reddit) in your own writing voice. Voice cloning learns from your past writing; no auto-publishing.
+- [ProposalCraft](https://github.com/jabbawocky/proposalcraft) - MCP server that drafts freelance client proposals in your voice, learned from your past winning work. Runs locally via Claude Desktop — no API key, no cloud, nothing leaves your machine. Free tier: 5 proposals/month.
 
 
 


### PR DESCRIPTION
## What this adds

[ProposalCraft](https://github.com/jabbawocky/proposalcraft) — an MCP server that drafts freelance client proposals in your voice, learned from your past winning work.

Added to **🆕 Additional AI and Productivity Tools** section.

## Why it fits

- Free to use (5 proposals/month, no account required)
- Runs entirely locally via Claude Desktop — no cloud, no API key, no data leaves your machine
- Fixes a real productivity problem: freelancers spend 9–12 unpaid hours/month on proposals
- `analyze_brief` tool identifies budget signals, scope risks, and key questions before you write a word
- MIT open source (TypeScript)

**GitHub:** https://github.com/jabbawocky/proposalcraft  
**Landing:** https://jabbawocky.github.io/proposalcraft/