### PR TITLE
Add cv.cm/v to Video Generation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1702,6 +1702,7 @@ This list includes a range of tools for AI-powered video generation, offering ca
 - [Shortodella](https://shortodella.com) - AI graphics platform with a canvas editor for image generation, video creation, chat-based editing, and background removal. Free tier available.
 - [HeyVid](https://heyvid.ai) - All-in-one AI video and image generator.
 - [UGCFast](https://ugcfast.ai) - AI UGC video ad generator with 300+ AI actors and 35+ languages, built for performance marketers shipping TikTok, Reels, and Meta ads.
+- [cv.cm/v](https://cv.cm/v) - Queue-free Seedance 2.0 text-to-video and image-to-video, plus gpt-image-2/Seedream image generation, with an open API.
 
 ---
 


### PR DESCRIPTION
Adds **cv.cm/v** to Video Generation Tools.

A clean, complete entry: cv.cm/v runs queue-free, full-power Seedance 2.0 text-to-video and image-to-video, plus gpt-image-2/Seedream image generation, with real-face support and an open developer API. Free credits for new users.