### PR TITLE
Add promptvv (video-to-prompt) to Video Generation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1698,6 +1698,7 @@ This list includes a range of tools for AI-powered video generation, offering ca
 - [ShortsKit.ai](https://shortskit.ai) - AI-powered platform for creating short-form videos
 - [MaxVideoAI](https://maxvideoai.com) - Multi-engine AI video generation hub (Sora, Veo, Wan, Kling, LTX…).
 - [TubePrompter](https://tubeprompter.com) - Free AI tool that converts YouTube, TikTok, and Instagram videos into optimized prompts for Sora, Veo, Midjourney, Runway Gen-3, Stable Diffusion, and other AI generators.
+- [promptvv](https://promptvv.com) - Reverse-engineers any video (or a Douyin/Xiaohongshu/Bilibili link) into structured AI video prompts — events, shots, camera moves, performance, and dialogue — ready to paste into Jimeng, Seedance, and Kling.
 - [ClipSpeedAI](https://clipspeed.ai) - AI-powered video clipping that automatically finds and extracts the best highlight moments from long-form videos for streamers and content creators.
 - [Shortodella](https://shortodella.com) - AI graphics platform with a canvas editor for image generation, video creation, chat-based editing, and background removal. Free tier available.
 - [HeyVid](https://heyvid.ai) - All-in-one AI video and image generator.


### PR DESCRIPTION
Adds **promptvv** to the **Video Generation Tools** section.

**What it is:** promptvv reverse-engineers any video into structured AI video prompts — events, shots, camera moves, performance, and dialogue — ready to paste into AI video generators (Jimeng / Seedance / Kling) to recreate it.

**Why it fits:** Same category as the existing **TubePrompter** entry (video → prompt), with a different angle — it accepts Douyin / Xiaohongshu / Bilibili links and outputs a shot-by-shot structured breakdown instead of a single prompt string. Placed right after TubePrompter.

- Public & functional (live, free tier on signup) — not a waitlist or landing page.
- Real, practical value for creators recreating videos with AI.

Thanks for maintaining the list!