### PR TITLE
Add Remio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1286,6 +1286,7 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 
 [🔝 Back to Top](#top)
 
+- [Remio](https://remio.ai/) - Local-first AI memory and knowledge base app that indexes files, notes, webpages, recordings, emails, messages, and images for faster semantic retrieval by users and agents.
 - [DeepL](https://www.deepl.com/translator) - Advanced Language Translation
 - [TensorFlow](https://www.tensorflow.org/) - Machine Learning Library
 - [Hugging Face](https://huggingface.co/) - NLP and Transformer Models


### PR DESCRIPTION
## Summary
- Add Remio to Additional AI and Productivity Tools

## Why
Remio is a public local-first AI memory and knowledge base app. It indexes files, notes, webpages, recordings, emails, messages, images, and other personal knowledge sources so users and agents can retrieve relevant context through semantic search instead of repeatedly scanning raw files or loading whole documents.

Disclosure: I am connected to Remio.