### PR TITLE
Add CreatorSkills to AI-Related Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1313,6 +1313,7 @@ A growing landscape of open-source personal agents, agent frameworks, and multi-
 - [UnSoloMind.com](https://unsolomind.com) – Knowledge base AI assistant
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time
 - [SummaryTube.com](https://summarytube.com) – AI Youtube Video Summarizer
+- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 - [Codeflash](https://www.codeflash.ai/) - Ship Blazing-Fast Python Code — Every Time
 - [helloandy.net AI Tools](https://helloandy.net) – Free AI writing and agent tools: Text Auditor, Humanizer, CLAUDE.md Writer, SKILL.md Generator, AI Writing Coach, and more. No account required.
 - [AI Text Auditor](https://helloandy.net/ai-text-auditor/) – Free tool that scores text against 28 AI writing patterns and returns a risk score


### PR DESCRIPTION
## What's being added

[CreatorSkills](https://creatorskills.co) — a marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.

## Why it belongs here

CreatorSkills fits in the **AI-Related Tools** section alongside other productivity and writing tools already listed (Grammarly, SummaryTube, etc.). It's a practical AI tool that content creators use to improve their YouTube and sponsorship workflows via Claude and ChatGPT skill prompts.