### PR TITLE
Add ArtImageHub to AI Tools for Photo Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1880,6 +1880,7 @@ A collection of AI-powered tools specifically designed for photo editing and enh
 20. [TouchRetouch](https://www.adva-soft.com/touchretouch/) - Remove objects from photos.
 21. [Igly](https://igly.ai) - AI image editor for background removal, replacement, upscale, restore, inpaint, and product-photo workflows.
 22. [PhotoRestore.ai](https://photorestore.ai) - AI-powered restoration of old and damaged photos — repairs scratches, fading, tears, and colorizes black-and-white images.
+23. [ArtImageHub](https://artimagehub.com/old-photo-restoration) - AI old photo restoration that repairs scratches, fading, and blur and colorizes black-and-white family photos in the browser.
 
 ---
 


### PR DESCRIPTION
Adds one new AI tool, **ArtImageHub**, to the *AI Tools for Photo Editing* section (entry #23), alongside the existing PhotoRestore.ai.

- **Name:** ArtImageHub
- **URL:** https://artimagehub.com/old-photo-restoration
- **What it does:** AI old photo restoration — repairs scratches, fading, and blur, and colorizes black-and-white family photos in the browser.

Single entry, correct category, link valid, not previously listed.