### PR TITLE
Add Feiyuan API gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1946,7 +1946,8 @@ A selection of platforms offering API integration for various AI applications an
 20. [ChatterOn](https://chatteron.io) - AI chatbot building platform with API.
 21. [YobiYoba](https://www.yobiyoba.com/en/) - The Yobiyoba API provides automatic transcription, real-time processing, audio-text alignment, and lexicon enhancement to enrich your audio transcriptions.
 22. [SkillBoss](https://skillboss.co) - Unified API gateway for 100+ AI models (Claude, GPT, Gemini, DeepSeek) plus image/video generation, payments, and infrastructure services. OpenAI-compatible.
-23. Many others support API integration too
+23. [Feiyuan API](https://feiyuanapi.com) - OpenAI-compatible API gateway for Claude, GPT, and multi-model clients such as Claude Code, Cherry Studio, LobeChat, and automation scripts.
+24. Many others support API integration too
 
 ---
 


### PR DESCRIPTION
Add Feiyuan API to the API integration section.

Feiyuan API is an OpenAI-compatible API gateway for Claude, GPT, and multi-model clients such as Claude Code, Cherry Studio, LobeChat, and automation scripts.

Disclosure: I am submitting this on behalf of the Feiyuan API project.
