### PR TITLE
Add BenchGen — AI agent evaluation platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,6 +1081,7 @@ This section covers the latest AI-driven robots, ranging from quadruped robotic 
 
 [🔝 Back to Top](#top)
 
+- **[BenchGen](https://benchgen.com)**: AI agent benchmarking and evaluation platform. Run structured benchmarks against your agent, score performance across tool-call accuracy, goal completion, and skill coverage, and export filtered trajectories for fine-tuning.
 - **[Archivarix Tube Search](https://tube.archivarix.net)**: Search engine over ~1.5 billion archived YouTube videos including deleted, private, or region-blocked content. Uses LLMs to generate detailed video summaries and auto-transcribe videos without captions. Free anonymous tier; MCP server available for AI assistants.
 - **[AI Engineer Pack](https://www.aiengineerpack.com/)**: Elevenlabs provided this engineer pack which includes a lot of offers like Perplexity pro free for a year, more.
 - **[AI Assistant for SMBs](https://openclawapp.netlify.app/assistant/)**: Managed AI assistant service for small businesses that executes work autonomously - handles calls, emails, reports, bookings. Integrates with business tools, learns workflows, runs 24/7.


### PR DESCRIPTION
Hi! Would love to add BenchGen (https://benchgen.com) to the AI-Related Tools section.

It's an AI agent benchmarking and evaluation platform — point it at your agent, run structured benchmark suites, and it scores performance across tool-call accuracy, goal completion, skill coverage, and regression stability. Also exports filtered trajectory data for fine-tuning. Feels like a good addition for developers building and shipping AI agents.

Happy to move it to a different section if you prefer.