### PR TITLE
Add TalkPix.ai to Video Generation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1702,6 +1702,7 @@ This list includes a range of tools for AI-powered video generation, offering ca
 - [Shortodella](https://shortodella.com) - AI graphics platform with a canvas editor for image generation, video creation, chat-based editing, and background removal. Free tier available.
 - [HeyVid](https://heyvid.ai) - All-in-one AI video and image generator.
 - [UGCFast](https://ugcfast.ai) - AI UGC video ad generator with 300+ AI actors and 35+ languages, built for performance marketers shipping TikTok, Reels, and Meta ads.
+- [TalkPix.ai](https://www.talkpix.ai)** – Pay-as-you-go AI video studio for creating lip-synced talking photos, e-commerce product video ads, and text-to-video clips without subscriptions.
 
 ---
 


### PR DESCRIPTION
Add TalkPix.ai to the Video Generation Tools category. TalkPix.ai is a pay-as-you-go AI video studio for creating talking photos, product video ads, and text-to-video clips.

Please complete the sections below.

Incomplete, duplicate, or incorrectly formatted submissions may be closed.

> PR reviews may take time depending on backlog and activity.

# Pull Request

Please fill in the sections below. Incomplete submissions may be closed.

If you're submitting a tool, just replace `[ ]` with `[x]` where applicable.

## Tool

**Name:** :
**URL:** :

### Type

* [ ] Website / SaaS
* [ ] Open-source repository
* [ ] Self-hosted tool
* [ ] AI model
* [ ] Other

### Relationship

* [ ] Creator
* [ ] Contributor
* [ ] User
* [ ] Not affiliated

## Description

**What does it do?**

<!-- Keep short -->

**Why should it be included?**

<!-- Optional -->

## Checks

* [ ] Publicly available
* [ ] Working link
* [ ] Not already listed
* [ ] Added to the correct category
* [ ] Description is short and neutral

Thanks for contributing.
