### PR TITLE
Add voxelyo to AI Tools for Photo Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1880,6 +1880,7 @@ A collection of AI-powered tools specifically designed for photo editing and enh
 20. [TouchRetouch](https://www.adva-soft.com/touchretouch/) - Remove objects from photos.
 21. [Igly](https://igly.ai) - AI image editor for background removal, replacement, upscale, restore, inpaint, and product-photo workflows.
 22. [PhotoRestore.ai](https://photorestore.ai) - AI-powered restoration of old and damaged photos — repairs scratches, fading, tears, and colorizes black-and-white images.
+23. [voxelyo](https://voxelyo.com) - AI photo enhancement for Airbnb, Vrbo, and real estate listing photos, including auto-enhance and virtual twilight conversion.
 
 ---
 


### PR DESCRIPTION
Adds voxelyo (https://voxelyo.com) to the AI Tools for Photo Editing section.

Disclosure: I'm the creator/maintainer of voxelyo, per the CONTRIBUTING.md request to note any connection to the tool.

- voxelyo is an AI photo-enhancement product focused on Airbnb, Vrbo, and real-estate listing photos (auto-enhance + virtual twilight/day-to-dusk conversion).
- Public, functional, and usable right now — not a waitlist or demo.
- One-line description, following the list's existing format.