### PR TITLE
Add foxue.ai — open-source Buddhist canon research platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,7 @@ This section covers the latest AI-driven robots, ranging from quadruped robotic 
 - [ai-i18n](https://github.com/i18n-actions/ai-i18n) - GitHub Action that automatically translates i18n files (XLIFF, JSON) using LLM providers (Anthropic, OpenAI, Ollama) with glossary support, change detection, and reviewed translation preservation.
 - [AI Context Linter](https://github.com/MrDwarf7/ai-context-linter) - GitHub Action that lints AI coding context files (CLAUDE.md, .cursorrules, AGENTS.md) for security issues, structural problems, and AI anti-patterns.
 - [AI Context Templates](https://github.com/MrDwarf7/ai-context-templates) - Free CLAUDE.md, Cursor rules, and PRP templates that make AI coding assistants actually useful. 5 ready-to-use template packs for common project types.
+- [foxue.ai](https://www.foxue.ai) - Open-source Buddhist canon research platform (Apache-2.0, [GitHub](https://github.com/weitzu-com/foxue.ai)). Paragraph-level cited reading across Chinese (CBETA), Pali, Sanskrit, and Tibetan (Derge Kangyur) canons; its Q&A layer only synthesizes verified evidence and answers "no reliable source found" instead of fabricating.
 - [url-to-md](https://github.com/MrDwarf7/url-to-md) - Any URL to clean markdown for LLMs. Free API, no signup required. Strips JS/CSS and outputs LLM-ready content.
 - [TensorFlow Machine Learning Library](https://www.tensorflow.org/) - Comprehensive open-source machine learning framework.
 - [Hugging Face NLP & Model Hub](https://huggingface.co/) - Extensive repository of NLP models and datasets.


### PR DESCRIPTION
## What

Add foxue.ai to the AI-Related Tools section.

- Public and functional today: ~252k paragraph-level pages across Chinese (CBETA Taisho), Pali (full Tipitaka), Sanskrit, and Tibetan (Derge Kangyur) canons
- Open source, Apache-2.0: https://github.com/weitzu-com/foxue.ai
- Differentiator: Q&A layer only synthesizes verified evidence; answers "no reliable source found" rather than hallucinating — an evidence-first design for religious text AI
- Aligns with the list's principles: public, functional, real value

🤖 Generated with [Claude Code](https://claude.com/claude-code)