### PR TITLE
Add Piclisto Listing Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1563,6 +1563,7 @@ The following are online platforms where you can rent GPU resources, ideal for r
 
 This list highlights a selection of image generation tools, featuring advanced AI technologies such as Stable Diffusion, MidJourney, and DALL-E 3, among others. These tools offer a range of functionalities, from creating artistic visuals to generating realistic images.
 
+- [Piclisto Listing Generator](https://piclisto.com/listing-generator) - Creates coordinated ecommerce listing image sets from uploaded product photos.
 - [Stable Diffusion](https://stablediffusion.com) - AI model for stable and high-quality image generation.
 - [MidJourney](https://midjourney.com) - Advanced tool for AI-driven artistic image creation.
 - [DALL-E 3](https://openai.com/dall-e-3) - Latest iteration of OpenAI's powerful image generation model.


### PR DESCRIPTION
Adds Piclisto Listing Generator to Image Generation Tools. It helps ecommerce sellers create coordinated listing image sets from uploaded product photos.

I am submitting this on behalf of the product team. An AI agent helped prepare this factual entry. The linked page is public, and the product provides an application entry point.

The current README and open and closed pull requests were checked for a Piclisto duplicate before this contribution.